### PR TITLE
build: remove peer dependency from plugins

### DIFF
--- a/packages/plugin-aws-sdk/package.json
+++ b/packages/plugin-aws-sdk/package.json
@@ -47,7 +47,6 @@
     "ts-jest": "^26.1.0",
     "typescript": "^3.9.5"
   },
-  "peerDependencies": {},
   "dependencies": {
     "@opentelemetry/core": "^0.8.3",
     "shimmer": "^1.2.1"

--- a/packages/plugin-aws-sdk/package.json
+++ b/packages/plugin-aws-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentelemetry-plugin-aws-sdk",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "open telemetry instrumentation for the `aws-sdk` package",
   "keywords": [
     "aws",

--- a/packages/plugin-aws-sdk/src/aws-sdk.ts
+++ b/packages/plugin-aws-sdk/src/aws-sdk.ts
@@ -16,7 +16,7 @@ import { AttributeNames } from "./enums";
 import { ServicesExtensions } from "./services";
 import { AwsSdkPluginConfig } from "./types";
 
-const VERSION = "0.0.4";
+const VERSION = "0.0.5";
 
 class AwsPlugin extends BasePlugin<typeof AWS> {
   readonly component: string;

--- a/packages/plugin-kafkajs/package.json
+++ b/packages/plugin-kafkajs/package.json
@@ -44,9 +44,6 @@
         "ts-jest": "^26.1.0",
         "typescript": "^3.9.5"
     },
-    "peerDependencies": {
-        "kafkajs": "^1.12.0"
-    },
     "dependencies": {
         "@opentelemetry/core": "^0.8.3",
         "shimmer": "^1.2.1"


### PR DESCRIPTION
Plugins should not have peer dependency on the library they are instrumenting. It should have dev dependency only