### PR TITLE
chore: fix prerelease github action

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -33,4 +33,4 @@ jobs:
 
       - name: Publish package
         run: |
-          yarn publish:ci:prerelease --preid $(echo ${GITHUB_REF##*/}) patch
+          yarn publish:ci:prerelease 0.0.0-$(date +"%Y-%m-%d--%H-%M")

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "version:update": "lerna run version:update",
         "version": "git add packages/**/version.ts",
         "publish:ci": "lerna publish --yes --allow-branch master --create-release github --conventionalCommits",
-        "publish:ci:prerelease": "lerna publish --no-git-tag-version --no-push --no-changelog --dist-tag canary"
+        "publish:ci:prerelease": "lerna publish --yes --no-git-tag-version --no-push --no-changelog --dist-tag canary"
     },
     "devDependencies": {
         "lerna": "^3.22.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "version:update": "lerna run version:update",
         "version": "git add packages/**/version.ts",
         "publish:ci": "lerna publish --yes --allow-branch master --create-release github --conventionalCommits",
-        "publish:ci:prerelease": "lerna publish --yes --no-git-tag-version --no-push --no-changelog --dist-tag canary"
+        "publish:ci:prerelease": "lerna publish --yes --no-git-tag-version --no-push --no-changelog --dist-tag alpha"
     },
     "devDependencies": {
         "lerna": "^3.22.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "version:update": "lerna run version:update",
         "version": "git add packages/**/version.ts",
         "publish:ci": "lerna publish --yes --allow-branch master --create-release github --conventionalCommits",
-        "publish:ci:prerelease": "lerna publish --yes --canary"
+        "publish:ci:prerelease": "lerna publish --no-git-tag-version --no-push --no-changelog --dist-tag canary"
     },
     "devDependencies": {
         "lerna": "^3.22.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "build:ci": "lerna run build",
         "postinstall": "lerna bootstrap",
         "prettier": "prettier --config .prettierrc.yml --write --ignore-unknown \"**/*\"",
-        "prettier:check": "npx prettier --config .prettierrc.yml --check --ignore-unknown \"**/*\"",
+        "prettier:check": "npx prettier@2.2.1 --config .prettierrc.yml --check --ignore-unknown \"**/*\"",
         "version:update": "lerna run version:update",
         "version": "git add packages/**/version.ts",
         "publish:ci": "lerna publish --yes --allow-branch master --create-release github --conventionalCommits",


### PR DESCRIPTION
[Monday issue](https://aspecto-io.monday.com/boards/312932205/pulses/1172560562)

In this pr I changed the preRelease github action. 

Prerelease versions will use the following format: 
`0.0.0-YYYY-MM-DD--hh-mm` for example: `0.0.0-2021-05-11--17-34`