### PR TITLE
fix(instrumentation-neo4j): support neo4j driver >=4.3.0

### DIFF
--- a/packages/instrumentation-neo4j/package.json
+++ b/packages/instrumentation-neo4j/package.json
@@ -31,10 +31,10 @@
         "prepare": "yarn run build",
         "test": "mocha",
         "test:ci": "tav",
+        "test:docker:run": "docker run -d -p7474:7474 -p11011:7687 -e NEO4J_AUTH=neo4j/test neo4j:4.2.3",
         "watch": "tsc -w",
         "version:update": "node ../../scripts/version-update.js",
-        "version": "yarn run version:update",
-        "test:docker:run": "docker run -d -p7474:7474 -p11011:7687 -e NEO4J_AUTH=neo4j/test neo4j:4.2.3"
+        "version": "yarn run version:update"
     },
     "bugs": {
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"

--- a/packages/instrumentation-neo4j/package.json
+++ b/packages/instrumentation-neo4j/package.json
@@ -33,7 +33,8 @@
         "test:ci": "tav",
         "watch": "tsc -w",
         "version:update": "node ../../scripts/version-update.js",
-        "version": "yarn run version:update"
+        "version": "yarn run version:update",
+        "test:docker:run": "docker run -d -p7474:7474 -p11011:7687 -e NEO4J_AUTH=neo4j/test neo4j:4.2.3"
     },
     "bugs": {
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"


### PR DESCRIPTION
neo4j released a new version 4.3.0 where the internal files structure has changed and we need to take the right file when patching depending on the package version

https://aspecto-io.monday.com/boards/312932205/pulses/1341435063