### PR TITLE
chore: update otel sdk to v0.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The instrumentations in this repo are:
 - strictly complies with [open telemetry semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions)
 - up to date with latest SDK version
 
-**Compatible with [SDK v0.19.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v0.19.0)**
+**Compatible with [SDK v0.20.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v0.20.0)**
 ## Instrumentations
 | Instrumentation Package | Instrumented Lib | NPM |
 | --- | --- | --- |
@@ -45,10 +45,11 @@ The instrumentations in this repo are:
 |[opentelemetry-instrumentation-socket.io](./packages/instrumentation-socket.io) | [socket.io](https://github.com/socketio/socket.io) | [![NPM version](https://img.shields.io/npm/v/opentelemetry-instrumentation-socket.io.svg)](https://www.npmjs.com/package/opentelemetry-instrumentation-socket.io)
 
 ## Compatability Table
-**Tested and verified against otel v0.19.0**
+**Tested and verified against otel v0.20.0**
 
 | Instrumentations Version | OpenTelemetry Version |
 | --- | --- |
+| 0.5.x | 0.20.0 |
 | 0.4.x | 0.19.0 |
 | 0.3.x | 0.18.0 |
 | 0.2.x | 0.17.0 |

--- a/package.json
+++ b/package.json
@@ -22,5 +22,6 @@
     },
     "workspaces": [
         "packages/*"
-    ]
+    ],
+    "version": "0.50.0"
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,5 @@
     },
     "workspaces": [
         "packages/*"
-    ],
-    "version": "0.50.0"
+    ]
 }

--- a/packages/instrumentation-amqplib/package.json
+++ b/packages/instrumentation-amqplib/package.json
@@ -51,7 +51,7 @@
         "expect": "^26.6.2",
         "lodash": "^4.17.21",
         "mocha": "^8.4.0",
-        "opentelemetry-instrumentation-mocha": "^0.0.1-rc.0",
+        "opentelemetry-instrumentation-mocha": "^0.0.1-rc.1",
         "opentelemetry-instrumentation-testing-utils": "^0.4.1",
         "sinon": "^9.2.4",
         "test-all-versions": "^5.0.1",

--- a/packages/instrumentation-amqplib/package.json
+++ b/packages/instrumentation-amqplib/package.json
@@ -37,12 +37,12 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "dependencies": {
-        "@opentelemetry/api": "^1.0.0-rc.0",
+        "@opentelemetry/api": "^0.20.0",
         "@opentelemetry/instrumentation": "^0.20.0",
         "@opentelemetry/semantic-conventions": "^0.20.0"
     },
     "devDependencies": {
-        "@opentelemetry/core": "^0.19.0",
+        "@opentelemetry/core": "^0.20.0",
         "@types/amqplib": "^0.5.17",
         "@types/lodash": "^4.14.168",
         "@types/mocha": "^8.2.2",

--- a/packages/instrumentation-amqplib/package.json
+++ b/packages/instrumentation-amqplib/package.json
@@ -38,8 +38,8 @@
     },
     "dependencies": {
         "@opentelemetry/api": "^1.0.0-rc.0",
-        "@opentelemetry/instrumentation": "^0.19.0",
-        "@opentelemetry/semantic-conventions": "^0.19.0"
+        "@opentelemetry/instrumentation": "^0.20.0",
+        "@opentelemetry/semantic-conventions": "^0.20.0"
     },
     "devDependencies": {
         "@opentelemetry/core": "^0.19.0",

--- a/packages/instrumentation-amqplib/src/amqplib.ts
+++ b/packages/instrumentation-amqplib/src/amqplib.ts
@@ -1,4 +1,4 @@
-import { context, diag, propagation, setSpan, Span, SpanKind, SpanStatusCode } from '@opentelemetry/api';
+import { context, diag, propagation, trace, Span, SpanKind, SpanStatusCode } from '@opentelemetry/api';
 import {
     InstrumentationBase,
     InstrumentationModuleDefinition,
@@ -280,7 +280,7 @@ export class AmqplibInstrumentation extends InstrumentationBase<typeof amqp> {
                     });
                 }
 
-                context.with(setSpan(context.active(), span), () => {
+                context.with(trace.setSpan(context.active(), span), () => {
                     onMessage.call(this, msg);
                 });
 
@@ -322,7 +322,7 @@ export class AmqplibInstrumentation extends InstrumentationBase<typeof amqp> {
 
             const modifiedOptions = options ?? {};
             modifiedOptions.headers = modifiedOptions.headers ?? {};
-            propagation.inject(setSpan(context.active(), span), modifiedOptions.headers);
+            propagation.inject(trace.setSpan(context.active(), span), modifiedOptions.headers);
 
             if (self._config.publishHook) {
                 safeExecuteInTheMiddle(

--- a/packages/instrumentation-amqplib/test/amqplib-callbacks.spec.ts
+++ b/packages/instrumentation-amqplib/test/amqplib-callbacks.spec.ts
@@ -100,8 +100,8 @@ describe('amqplib instrumentation callback model', function () {
             expect(consumeSpan.attributes[SemanticAttributes.NET_PEER_PORT]).toEqual(TEST_RABBITMQ_PORT);
 
             // assert context propagation
-            expect(consumeSpan.spanContext.traceId).toEqual(publishSpan.spanContext.traceId);
-            expect(consumeSpan.parentSpanId).toEqual(publishSpan.spanContext.spanId);
+            expect(consumeSpan.spanContext().traceId).toEqual(publishSpan.spanContext().traceId);
+            expect(consumeSpan.parentSpanId).toEqual(publishSpan.spanContext().spanId);
 
             done();
         });

--- a/packages/instrumentation-amqplib/test/amqplib-promise.spec.ts
+++ b/packages/instrumentation-amqplib/test/amqplib-promise.spec.ts
@@ -122,8 +122,8 @@ describe('amqplib instrumentation promise model', function () {
         expect(consumeSpan.attributes[SemanticAttributes.NET_PEER_PORT]).toEqual(TEST_RABBITMQ_PORT);
 
         // assert context propagation
-        expect(consumeSpan.spanContext.traceId).toEqual(publishSpan.spanContext.traceId);
-        expect(consumeSpan.parentSpanId).toEqual(publishSpan.spanContext.spanId);
+        expect(consumeSpan.spanContext().traceId).toEqual(publishSpan.spanContext().traceId);
+        expect(consumeSpan.parentSpanId).toEqual(publishSpan.spanContext().spanId);
 
         expectConsumeEndSpyStatus([EndOperation.AutoAck]);
     });
@@ -384,8 +384,8 @@ describe('amqplib instrumentation promise model', function () {
             expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]).toEqual('0.9.1');
 
             // assert context propagation
-            expect(consumeSpan.spanContext.traceId).toEqual(publishSpan.spanContext.traceId);
-            expect(consumeSpan.parentSpanId).toEqual(publishSpan.spanContext.spanId);
+            expect(consumeSpan.spanContext().traceId).toEqual(publishSpan.spanContext().traceId);
+            expect(consumeSpan.parentSpanId).toEqual(publishSpan.spanContext().spanId);
         });
     });
 

--- a/packages/instrumentation-aws-sdk/.tav.yml
+++ b/packages/instrumentation-aws-sdk/.tav.yml
@@ -1,7 +1,7 @@
 'aws-sdk':
   # there are so many version to test, it can take forever.
   # we will just sample few of them
-  versions: ">=2.900.0 || 2.706.0 || 2.608.0 || 2.518.0 || 2.422.0 || 2.315.0 || 2.224.1 || 2.122.0 || 2.59.0"
+  versions: "2.900.0 || 2.706.0 || 2.608.0 || 2.518.0 || 2.422.0 || 2.315.0 || 2.224.1 || 2.122.0 || 2.59.0"
   commands:
     - yarn test
 

--- a/packages/instrumentation-aws-sdk/.tav.yml
+++ b/packages/instrumentation-aws-sdk/.tav.yml
@@ -1,7 +1,7 @@
 'aws-sdk':
   # there are so many version to test, it can take forever.
   # we will just sample few of them
-  versions: "2.900.0 || 2.706.0 || 2.608.0 || 2.518.0 || 2.422.0 || 2.315.0 || 2.224.1 || 2.122.0 || 2.59.0"
+  versions: ">=2.880.0 || 2.706.0 || 2.608.0 || 2.518.0 || 2.422.0 || 2.315.0 || 2.224.1 || 2.122.0 || 2.59.0"
   commands:
     - yarn test
 

--- a/packages/instrumentation-aws-sdk/.tav.yml
+++ b/packages/instrumentation-aws-sdk/.tav.yml
@@ -1,7 +1,7 @@
 'aws-sdk':
   # there are so many version to test, it can take forever.
   # we will just sample few of them
-  versions: ">=2.880.0 || 2.706.0 || 2.608.0 || 2.518.0 || 2.422.0 || 2.315.0 || 2.224.1 || 2.122.0 || 2.59.0"
+  versions: ">=2.900.0 || 2.706.0 || 2.608.0 || 2.518.0 || 2.422.0 || 2.315.0 || 2.224.1 || 2.122.0 || 2.59.0"
   commands:
     - yarn test
 

--- a/packages/instrumentation-aws-sdk/package.json
+++ b/packages/instrumentation-aws-sdk/package.json
@@ -51,7 +51,7 @@
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
         "nock": "^13.0.11",
-        "opentelemetry-instrumentation-mocha": "^0.0.1-rc.0",
+        "opentelemetry-instrumentation-mocha": "^0.0.1-rc.1",
         "opentelemetry-instrumentation-testing-utils": "^0.4.1",
         "test-all-versions": "^5.0.1",
         "ts-node": "^9.1.1",

--- a/packages/instrumentation-aws-sdk/package.json
+++ b/packages/instrumentation-aws-sdk/package.json
@@ -35,7 +35,8 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "dependencies": {
-        "@opentelemetry/api": "^1.0.0-rc.0",
+        "@opentelemetry/api": "^0.20.0",
+        "@opentelemetry/core": "^0.20.0",
         "@opentelemetry/instrumentation": "^0.20.0",
         "@opentelemetry/semantic-conventions": "^0.20.0",
         "opentelemetry-propagation-utils": "^0.6.2"
@@ -44,7 +45,7 @@
         "@aws-sdk/client-s3": "3.13.1",
         "@aws-sdk/client-sqs": "3.13.1",
         "@aws-sdk/types": "3.13.1",
-        "@opentelemetry/tracing": "^0.19.0",
+        "@opentelemetry/tracing": "^0.20.0",
         "@types/mocha": "^8.2.2",
         "aws-sdk": "^2.780.0",
         "expect": "^26.6.2",

--- a/packages/instrumentation-aws-sdk/package.json
+++ b/packages/instrumentation-aws-sdk/package.json
@@ -36,8 +36,8 @@
     },
     "dependencies": {
         "@opentelemetry/api": "^1.0.0-rc.0",
-        "@opentelemetry/instrumentation": "^0.19.0",
-        "@opentelemetry/semantic-conventions": "^0.19.0",
+        "@opentelemetry/instrumentation": "^0.20.0",
+        "@opentelemetry/semantic-conventions": "^0.20.0",
         "opentelemetry-propagation-utils": "^0.6.2"
     },
     "devDependencies": {

--- a/packages/instrumentation-aws-sdk/src/services/sqs.ts
+++ b/packages/instrumentation-aws-sdk/src/services/sqs.ts
@@ -6,7 +6,7 @@ import {
     diag,
     TextMapGetter,
     TextMapSetter,
-    setSpan,
+    trace,
     context,
     ROOT_CONTEXT,
 } from '@opentelemetry/api';
@@ -120,7 +120,7 @@ export class SqsServiceExtension implements ServiceExtension {
 
             pubsubPropagation.patchMessagesArrayToStartProcessSpans<SQS.Message>({
                 messages,
-                parentContext: setSpan(context.active(), span),
+                parentContext: trace.setSpan(context.active(), span),
                 tracer,
                 messageToSpanDetails: (message: SQS.Message) => ({
                     name: queueName,

--- a/packages/instrumentation-aws-sdk/test/aws-sdk-v3.spec.ts
+++ b/packages/instrumentation-aws-sdk/test/aws-sdk-v3.spec.ts
@@ -5,7 +5,7 @@ process.env.AWS_SECRET_ACCESS_KEY = 'testing';
 import 'mocha';
 import { AwsInstrumentation, NormalizedRequest, NormalizedResponse } from '../src';
 import { ReadableSpan, Span } from '@opentelemetry/tracing';
-import { context, SpanStatusCode, getSpan } from '@opentelemetry/api';
+import { context, SpanStatusCode, trace } from '@opentelemetry/api';
 import {
     MessagingDestinationKindValues,
     MessagingOperationValues,
@@ -248,7 +248,7 @@ describe('instrumentation-aws-sdk-v3', () => {
                     expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('sqs');
                     expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
 
-                    const receiveCallbackSpan = getSpan(context.active());
+                    const receiveCallbackSpan = trace.getSpan(context.active());
                     expect(receiveCallbackSpan).toBeDefined();
                     const attributes = (receiveCallbackSpan as unknown as ReadableSpan).attributes;
                     expect(attributes[SemanticAttributes.MESSAGING_OPERATION]).toMatch(

--- a/packages/instrumentation-aws-sdk/test/sqs.spec.ts
+++ b/packages/instrumentation-aws-sdk/test/sqs.spec.ts
@@ -58,7 +58,7 @@ describe('sqs', () => {
             expect(awsReceiveSpan.length).toBe(1);
             const internalSpan = spans.filter((s) => s.kind === SpanKind.INTERNAL);
             expect(internalSpan.length).toBe(1);
-            expect(internalSpan[0].parentSpanId).toStrictEqual(awsReceiveSpan[0].spanContext.spanId);
+            expect(internalSpan[0].parentSpanId).toStrictEqual(awsReceiveSpan[0].spanContext().spanId);
         };
 
         it('should set parent context in sqs receive callback', (done) => {
@@ -157,14 +157,14 @@ describe('sqs', () => {
                 (s) => s.attributes[SemanticAttributes.MESSAGING_OPERATION] === 'process'
             );
             expect(processSpans.length).toBe(2);
-            expect(processSpans[0].parentSpanId).toStrictEqual(awsReceiveSpan[0].spanContext.spanId);
-            expect(processSpans[1].parentSpanId).toStrictEqual(awsReceiveSpan[0].spanContext.spanId);
+            expect(processSpans[0].parentSpanId).toStrictEqual(awsReceiveSpan[0].spanContext().spanId);
+            expect(processSpans[1].parentSpanId).toStrictEqual(awsReceiveSpan[0].spanContext().spanId);
 
             const processChildSpans = spans.filter((s) => s.kind === SpanKind.INTERNAL);
             expect(processChildSpans.length).toBe(2 * numChildPerProcessSpan);
             for (let i = 0; i < numChildPerProcessSpan; i++) {
-                expect(processChildSpans[2 * i + 0].parentSpanId).toStrictEqual(processSpans[0].spanContext.spanId);
-                expect(processChildSpans[2 * i + 1].parentSpanId).toStrictEqual(processSpans[1].spanContext.spanId);
+                expect(processChildSpans[2 * i + 0].parentSpanId).toStrictEqual(processSpans[0].spanContext().spanId);
+                expect(processChildSpans[2 * i + 1].parentSpanId).toStrictEqual(processSpans[1].spanContext().spanId);
             }
         };
 

--- a/packages/instrumentation-aws-sdk/test/testing-utils.ts
+++ b/packages/instrumentation-aws-sdk/test/testing-utils.ts
@@ -1,4 +1,5 @@
-import { isInstrumentationSuppressed, context } from '@opentelemetry/api';
+import { context } from '@opentelemetry/api';
+import { isTracingSuppressed } from '@opentelemetry/core';
 import expect from 'expect';
 import AWS from 'aws-sdk';
 
@@ -8,7 +9,7 @@ export const mockAwsSend = (
     expectedInstrumentationSuppressed: boolean = false
 ) => {
     AWS.Request.prototype.send = function (cb?: (error, response) => void) {
-        expect(isInstrumentationSuppressed(context.active())).toStrictEqual(expectedInstrumentationSuppressed);
+        expect(isTracingSuppressed(context.active())).toStrictEqual(expectedInstrumentationSuppressed);
         if (cb) {
             (this as AWS.Request<any, any>).on('complete', (response) => {
                 cb(response.error, response);
@@ -26,7 +27,7 @@ export const mockAwsSend = (
     };
 
     AWS.Request.prototype.promise = function () {
-        expect(isInstrumentationSuppressed(context.active())).toStrictEqual(expectedInstrumentationSuppressed);
+        expect(isTracingSuppressed(context.active())).toStrictEqual(expectedInstrumentationSuppressed);
         const response = {
             ...sendResult,
             data,

--- a/packages/instrumentation-elasticsearch/package.json
+++ b/packages/instrumentation-elasticsearch/package.json
@@ -54,7 +54,7 @@
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
         "nock": "^13.0.9",
-        "opentelemetry-instrumentation-mocha": "^0.0.1-rc.0",
+        "opentelemetry-instrumentation-mocha": "^0.0.1-rc.1",
         "opentelemetry-instrumentation-testing-utils": "^0.4.1",
         "sinon": "^9.2.4",
         "test-all-versions": "^5.0.1",

--- a/packages/instrumentation-elasticsearch/package.json
+++ b/packages/instrumentation-elasticsearch/package.json
@@ -41,7 +41,8 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "dependencies": {
-        "@opentelemetry/api": "^1.0.0-rc.0",
+        "@opentelemetry/api": "^0.20.0",
+        "@opentelemetry/core": "^0.20.0",
         "@opentelemetry/instrumentation": "^0.20.0",
         "@opentelemetry/semantic-conventions": "^0.20.0"
     },

--- a/packages/instrumentation-elasticsearch/package.json
+++ b/packages/instrumentation-elasticsearch/package.json
@@ -42,8 +42,8 @@
     },
     "dependencies": {
         "@opentelemetry/api": "^1.0.0-rc.0",
-        "@opentelemetry/instrumentation": "^0.19.0",
-        "@opentelemetry/semantic-conventions": "^0.19.0"
+        "@opentelemetry/instrumentation": "^0.20.0",
+        "@opentelemetry/semantic-conventions": "^0.20.0"
     },
     "devDependencies": {
         "@elastic/elasticsearch": "^7.8.0",

--- a/packages/instrumentation-elasticsearch/src/elasticsearch.ts
+++ b/packages/instrumentation-elasticsearch/src/elasticsearch.ts
@@ -1,4 +1,5 @@
-import { diag, context, suppressInstrumentation, setSpan, Span } from '@opentelemetry/api';
+import { diag, context, trace, Span } from '@opentelemetry/api';
+import { suppressTracing } from '@opentelemetry/core';
 import type elasticsearch from '@elastic/elasticsearch';
 import { ElasticsearchInstrumentationConfig } from './types';
 import {
@@ -162,9 +163,9 @@ export class ElasticsearchInstrumentation extends InstrumentationBase<typeof ela
 
     private _callOriginalFunction<T>(span: Span, originalFunction: (...args: any[]) => T): T {
         if (this._config?.suppressInternalInstrumentation) {
-            return context.with(suppressInstrumentation(context.active()), originalFunction);
+            return context.with(suppressTracing(context.active()), originalFunction);
         } else {
-            const activeContextWithSpan = setSpan(context.active(), span);
+            const activeContextWithSpan = trace.setSpan(context.active(), span);
             return context.with(activeContextWithSpan, originalFunction);
         }
     }

--- a/packages/instrumentation-elasticsearch/test/utils.spec.ts
+++ b/packages/instrumentation-elasticsearch/test/utils.spec.ts
@@ -10,7 +10,7 @@ describe('elasticsearch utils', () => {
         recordException: (err) => {},
         setStatus: (obj) => {},
         end: () => {},
-        setAttributes: (obj) => {}
+        setAttributes: (obj) => {},
     };
 
     context('defaultDbStatementSerializer', () => {
@@ -174,7 +174,7 @@ describe('elasticsearch utils', () => {
     context('startSpan', () => {
         const tracerMock = {
             startSpan: (name, options?, context?): any => {},
-            startActiveSpan: () => {}
+            startActiveSpan: () => {},
         };
         it('should start span with client kind', () => {
             const startSpanStub = stub(tracerMock, 'startSpan');

--- a/packages/instrumentation-elasticsearch/test/utils.spec.ts
+++ b/packages/instrumentation-elasticsearch/test/utils.spec.ts
@@ -10,7 +10,7 @@ describe('elasticsearch utils', () => {
         recordException: (err) => {},
         setStatus: (obj) => {},
         end: () => {},
-        setAttributes: (obj) => {},
+        setAttributes: (obj) => {}
     };
 
     context('defaultDbStatementSerializer', () => {
@@ -174,6 +174,7 @@ describe('elasticsearch utils', () => {
     context('startSpan', () => {
         const tracerMock = {
             startSpan: (name, options?, context?): any => {},
+            startActiveSpan: () => {}
         };
         it('should start span with client kind', () => {
             const startSpanStub = stub(tracerMock, 'startSpan');

--- a/packages/instrumentation-express/package.json
+++ b/packages/instrumentation-express/package.json
@@ -32,8 +32,8 @@
     },
     "dependencies": {
         "@opentelemetry/api": "^1.0.0-rc.0",
-        "@opentelemetry/instrumentation": "^0.19.0",
-        "@opentelemetry/semantic-conventions": "^0.19.0"
+        "@opentelemetry/instrumentation": "^0.20.0",
+        "@opentelemetry/semantic-conventions": "^0.20.0"
     },
     "devDependencies": {
         "@opentelemetry/instrumentation-http": "^0.19.0",

--- a/packages/instrumentation-express/package.json
+++ b/packages/instrumentation-express/package.json
@@ -31,13 +31,13 @@
         "access": "public"
     },
     "dependencies": {
-        "@opentelemetry/api": "^1.0.0-rc.0",
+        "@opentelemetry/api": "^0.20.0",
         "@opentelemetry/instrumentation": "^0.20.0",
         "@opentelemetry/semantic-conventions": "^0.20.0"
     },
     "devDependencies": {
-        "@opentelemetry/instrumentation-http": "^0.19.0",
-        "@opentelemetry/tracing": "^0.19.0",
+        "@opentelemetry/instrumentation-http": "^0.20.0",
+        "@opentelemetry/tracing": "^0.20.0",
         "@types/express": "4.17.8",
         "@types/mocha": "^8.2.2",
         "axios": "0.21.1",

--- a/packages/instrumentation-express/package.json
+++ b/packages/instrumentation-express/package.json
@@ -45,7 +45,7 @@
         "expect": "^26.6.2",
         "express": "4.17.1",
         "mocha": "^8.4.0",
-        "opentelemetry-instrumentation-mocha": "^0.0.1-rc.0",
+        "opentelemetry-instrumentation-mocha": "^0.0.1-rc.1",
         "opentelemetry-instrumentation-testing-utils": "^0.4.1",
         "test-all-versions": "^5.0.1"
     },

--- a/packages/instrumentation-express/package.json
+++ b/packages/instrumentation-express/package.json
@@ -32,6 +32,7 @@
     },
     "dependencies": {
         "@opentelemetry/api": "^0.20.0",
+        "@opentelemetry/core": "^0.20.0",
         "@opentelemetry/instrumentation": "^0.20.0",
         "@opentelemetry/semantic-conventions": "^0.20.0"
     },

--- a/packages/instrumentation-express/src/express.ts
+++ b/packages/instrumentation-express/src/express.ts
@@ -1,3 +1,4 @@
+import { getRPCMetadata } from '@opentelemetry/core';
 import { SpanKind, diag, context } from '@opentelemetry/api';
 import {
     LayerPath,
@@ -227,7 +228,8 @@ export class ExpressInstrumentation extends InstrumentationBase<typeof express> 
                 const routeAttributes = getRouteAttributes(routeState);
                 const route = routeAttributes[SemanticAttributes.HTTP_ROUTE] as string;
                 if (route) {
-                    req.__ot_middlewares = [route];
+                    const rpcMetadata = getRPCMetadata(context.active());
+                    rpcMetadata.route = route;
                 }
 
                 oldResEnd.apply(res, arguments);

--- a/packages/instrumentation-express/src/express.ts
+++ b/packages/instrumentation-express/src/express.ts
@@ -229,7 +229,9 @@ export class ExpressInstrumentation extends InstrumentationBase<typeof express> 
                 const route = routeAttributes[SemanticAttributes.HTTP_ROUTE] as string;
                 if (route) {
                     const rpcMetadata = getRPCMetadata(context.active());
-                    rpcMetadata.route = route;
+                    if(rpcMetadata){
+                        rpcMetadata.route = route;
+                    }
                 }
 
                 oldResEnd.apply(res, arguments);

--- a/packages/instrumentation-express/src/express.ts
+++ b/packages/instrumentation-express/src/express.ts
@@ -229,7 +229,7 @@ export class ExpressInstrumentation extends InstrumentationBase<typeof express> 
                 const route = routeAttributes[SemanticAttributes.HTTP_ROUTE] as string;
                 if (route) {
                     const rpcMetadata = getRPCMetadata(context.active());
-                    if(rpcMetadata){
+                    if (rpcMetadata) {
                         rpcMetadata.route = route;
                     }
                 }

--- a/packages/instrumentation-express/test/opentelemetry-express.spec.ts
+++ b/packages/instrumentation-express/test/opentelemetry-express.spec.ts
@@ -5,14 +5,14 @@ import { ExpressInstrumentation } from '../src';
 import { AddressInfo } from 'net';
 import { ReadableSpan } from '@opentelemetry/tracing';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
-import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
+//import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import * as bodyParser from 'body-parser';
 
 const instrumentation = new ExpressInstrumentation();
 // add http instrumentation so we can test proper assignment of route attribute.
-const httpInstrumentation = new HttpInstrumentation();
-httpInstrumentation.enable();
-httpInstrumentation.disable();
+// const httpInstrumentation = new HttpInstrumentation();
+// httpInstrumentation.enable();
+// httpInstrumentation.disable();
 instrumentation.enable();
 instrumentation.disable();
 
@@ -28,14 +28,14 @@ describe('opentelemetry-express', () => {
 
     before(() => {
         instrumentation.enable();
-        httpInstrumentation.enable();
+        //httpInstrumentation.enable();
         app = express();
         app.use(bodyParser.json());
     });
 
     after(() => {
         instrumentation.disable();
-        httpInstrumentation.disable();
+        //httpInstrumentation.disable();
     });
 
     it('express attributes', (done) => {

--- a/packages/instrumentation-express/test/opentelemetry-express.spec.ts
+++ b/packages/instrumentation-express/test/opentelemetry-express.spec.ts
@@ -5,14 +5,14 @@ import { ExpressInstrumentation } from '../src';
 import { AddressInfo } from 'net';
 import { ReadableSpan } from '@opentelemetry/tracing';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
-//import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
+import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import * as bodyParser from 'body-parser';
 
 const instrumentation = new ExpressInstrumentation();
 // add http instrumentation so we can test proper assignment of route attribute.
-// const httpInstrumentation = new HttpInstrumentation();
-// httpInstrumentation.enable();
-// httpInstrumentation.disable();
+const httpInstrumentation = new HttpInstrumentation();
+httpInstrumentation.enable();
+httpInstrumentation.disable();
 instrumentation.enable();
 instrumentation.disable();
 
@@ -28,14 +28,14 @@ describe('opentelemetry-express', () => {
 
     before(() => {
         instrumentation.enable();
-        //httpInstrumentation.enable();
+        httpInstrumentation.enable();
         app = express();
         app.use(bodyParser.json());
     });
 
     after(() => {
         instrumentation.disable();
-        //httpInstrumentation.disable();
+        httpInstrumentation.disable();
     });
 
     it('express attributes', (done) => {

--- a/packages/instrumentation-express/test/opentelemetry-express.spec.ts
+++ b/packages/instrumentation-express/test/opentelemetry-express.spec.ts
@@ -62,7 +62,6 @@ describe('opentelemetry-express', () => {
                 );
             } catch (err) {}
             try {
-                
                 const expressSpans: ReadableSpan[] = getExpressSpans();
                 expect(expressSpans.length).toBe(1);
                 const span: ReadableSpan = expressSpans[0];
@@ -79,8 +78,8 @@ describe('opentelemetry-express', () => {
                 expect(span.attributes[SemanticAttributes.HTTP_FLAVOR]).toBeUndefined();
                 expect(span.attributes[SemanticAttributes.NET_PEER_IP]).toBeUndefined();
 
-                 // http span route
-                 const [incomingHttpSpan] = getTestSpans().filter(
+                // http span route
+                const [incomingHttpSpan] = getTestSpans().filter(
                     (s) => s.kind === SpanKind.SERVER && s.instrumentationLibrary.name.includes('http')
                 );
                 expect(incomingHttpSpan.attributes[SemanticAttributes.HTTP_ROUTE]).toMatch('/toto/:id');

--- a/packages/instrumentation-express/test/opentelemetry-express.spec.ts
+++ b/packages/instrumentation-express/test/opentelemetry-express.spec.ts
@@ -62,10 +62,7 @@ describe('opentelemetry-express', () => {
                 );
             } catch (err) {}
             try {
-                 // http span route
-                 const [incomingHttpSpan] = getTestSpans().filter(
-                    (s) => s.kind === SpanKind.SERVER && s.instrumentationLibrary.name.includes('http')
-                );
+                
                 const expressSpans: ReadableSpan[] = getExpressSpans();
                 expect(expressSpans.length).toBe(1);
                 const span: ReadableSpan = expressSpans[0];
@@ -81,6 +78,11 @@ describe('opentelemetry-express', () => {
                 expect(span.attributes[SemanticAttributes.HTTP_HOST]).toBeUndefined();
                 expect(span.attributes[SemanticAttributes.HTTP_FLAVOR]).toBeUndefined();
                 expect(span.attributes[SemanticAttributes.NET_PEER_IP]).toBeUndefined();
+
+                 // http span route
+                 const [incomingHttpSpan] = getTestSpans().filter(
+                    (s) => s.kind === SpanKind.SERVER && s.instrumentationLibrary.name.includes('http')
+                );
                 expect(incomingHttpSpan.attributes[SemanticAttributes.HTTP_ROUTE]).toMatch('/toto/:id');
                 done();
             } catch (error) {

--- a/packages/instrumentation-express/test/opentelemetry-express.spec.ts
+++ b/packages/instrumentation-express/test/opentelemetry-express.spec.ts
@@ -62,6 +62,10 @@ describe('opentelemetry-express', () => {
                 );
             } catch (err) {}
             try {
+                 // http span route
+                 const [incomingHttpSpan] = getTestSpans().filter(
+                    (s) => s.kind === SpanKind.SERVER && s.instrumentationLibrary.name.includes('http')
+                );
                 const expressSpans: ReadableSpan[] = getExpressSpans();
                 expect(expressSpans.length).toBe(1);
                 const span: ReadableSpan = expressSpans[0];
@@ -77,6 +81,7 @@ describe('opentelemetry-express', () => {
                 expect(span.attributes[SemanticAttributes.HTTP_HOST]).toBeUndefined();
                 expect(span.attributes[SemanticAttributes.HTTP_FLAVOR]).toBeUndefined();
                 expect(span.attributes[SemanticAttributes.NET_PEER_IP]).toBeUndefined();
+                expect(incomingHttpSpan.attributes[SemanticAttributes.HTTP_ROUTE]).toMatch('/toto/:id');
                 done();
             } catch (error) {
                 done(error);

--- a/packages/instrumentation-express/test/opentelemetry-express.spec.ts
+++ b/packages/instrumentation-express/test/opentelemetry-express.spec.ts
@@ -61,31 +61,34 @@ describe('opentelemetry-express', () => {
                     }
                 );
             } catch (err) {}
+            try {
+                const expressSpans: ReadableSpan[] = getExpressSpans();
 
-            const expressSpans: ReadableSpan[] = getExpressSpans();
-            expect(expressSpans.length).toBe(1);
-            const span: ReadableSpan = expressSpans[0];
+                // http span route
+                const [incomingHttpSpan] = getTestSpans().filter(
+                    (s) => s.kind === SpanKind.SERVER && s.instrumentationLibrary.name.includes('http')
+                );
+                expect(expressSpans.length).toBe(1);
+                const span: ReadableSpan = expressSpans[0];
 
-            // Span name
-            expect(span.name).toBe('POST /toto/:id');
+                // Span name
+                expect(span.name).toBe('POST /toto/:id');
 
-            // HTTP Attributes
-            expect(span.attributes[SemanticAttributes.HTTP_METHOD]).toBeUndefined();
-            expect(span.attributes[SemanticAttributes.HTTP_TARGET]).toBeUndefined();
-            expect(span.attributes[SemanticAttributes.HTTP_SCHEME]).toBeUndefined();
-            expect(span.attributes[SemanticAttributes.HTTP_STATUS_CODE]).toBeUndefined();
-            expect(span.attributes[SemanticAttributes.HTTP_HOST]).toBeUndefined();
-            expect(span.attributes[SemanticAttributes.HTTP_FLAVOR]).toBeUndefined();
-            expect(span.attributes[SemanticAttributes.NET_PEER_IP]).toBeUndefined();
-
-            // http span route
-            const [incomingHttpSpan] = getTestSpans().filter(
-                (s) => s.kind === SpanKind.SERVER && s.instrumentationLibrary.name.includes('http')
-            );
-            expect(incomingHttpSpan.attributes[SemanticAttributes.HTTP_ROUTE]).toMatch('/toto/:id');
-
-            server.close();
-            done();
+                // HTTP Attributes
+                expect(span.attributes[SemanticAttributes.HTTP_METHOD]).toBeUndefined();
+                expect(span.attributes[SemanticAttributes.HTTP_TARGET]).toBeUndefined();
+                expect(span.attributes[SemanticAttributes.HTTP_SCHEME]).toBeUndefined();
+                expect(span.attributes[SemanticAttributes.HTTP_STATUS_CODE]).toBeUndefined();
+                expect(span.attributes[SemanticAttributes.HTTP_HOST]).toBeUndefined();
+                expect(span.attributes[SemanticAttributes.HTTP_FLAVOR]).toBeUndefined();
+                expect(span.attributes[SemanticAttributes.NET_PEER_IP]).toBeUndefined();
+                expect(incomingHttpSpan.attributes[SemanticAttributes.HTTP_ROUTE]).toMatch('/toto/:id');
+                done();
+            } catch (error) {
+                done(error);
+            } finally {
+                server.close();
+            }
         });
     });
 

--- a/packages/instrumentation-express/test/opentelemetry-express.spec.ts
+++ b/packages/instrumentation-express/test/opentelemetry-express.spec.ts
@@ -63,11 +63,6 @@ describe('opentelemetry-express', () => {
             } catch (err) {}
             try {
                 const expressSpans: ReadableSpan[] = getExpressSpans();
-
-                // http span route
-                const [incomingHttpSpan] = getTestSpans().filter(
-                    (s) => s.kind === SpanKind.SERVER && s.instrumentationLibrary.name.includes('http')
-                );
                 expect(expressSpans.length).toBe(1);
                 const span: ReadableSpan = expressSpans[0];
 
@@ -82,7 +77,6 @@ describe('opentelemetry-express', () => {
                 expect(span.attributes[SemanticAttributes.HTTP_HOST]).toBeUndefined();
                 expect(span.attributes[SemanticAttributes.HTTP_FLAVOR]).toBeUndefined();
                 expect(span.attributes[SemanticAttributes.NET_PEER_IP]).toBeUndefined();
-                expect(incomingHttpSpan.attributes[SemanticAttributes.HTTP_ROUTE]).toMatch('/toto/:id');
                 done();
             } catch (error) {
                 done(error);

--- a/packages/instrumentation-kafkajs/package.json
+++ b/packages/instrumentation-kafkajs/package.json
@@ -44,7 +44,7 @@
         "expect": "^26.6.2",
         "kafkajs": "^1.12.0",
         "mocha": "^8.4.0",
-        "opentelemetry-instrumentation-mocha": "^0.0.1-rc.0",
+        "opentelemetry-instrumentation-mocha": "^0.0.1-rc.1",
         "opentelemetry-instrumentation-testing-utils": "^0.4.1",
         "ts-node": "^9.1.1",
         "typescript": "^3.9.5"

--- a/packages/instrumentation-kafkajs/package.json
+++ b/packages/instrumentation-kafkajs/package.json
@@ -35,8 +35,8 @@
     },
     "dependencies": {
         "@opentelemetry/api": "^1.0.0-rc.0",
-        "@opentelemetry/instrumentation": "^0.19.0",
-        "@opentelemetry/semantic-conventions": "^0.19.0"
+        "@opentelemetry/instrumentation": "^0.20.0",
+        "@opentelemetry/semantic-conventions": "^0.20.0"
     },
     "devDependencies": {
         "@opentelemetry/tracing": "^0.19.0",

--- a/packages/instrumentation-kafkajs/package.json
+++ b/packages/instrumentation-kafkajs/package.json
@@ -34,12 +34,12 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "dependencies": {
-        "@opentelemetry/api": "^1.0.0-rc.0",
+        "@opentelemetry/api": "^0.20.0",
         "@opentelemetry/instrumentation": "^0.20.0",
         "@opentelemetry/semantic-conventions": "^0.20.0"
     },
     "devDependencies": {
-        "@opentelemetry/tracing": "^0.19.0",
+        "@opentelemetry/tracing": "^0.20.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "kafkajs": "^1.12.0",

--- a/packages/instrumentation-kafkajs/test/DummyPropagation.ts
+++ b/packages/instrumentation-kafkajs/test/DummyPropagation.ts
@@ -1,12 +1,4 @@
-import {
-    Context,
-    TraceFlags,
-    TextMapPropagator,
-    TextMapSetter,
-    TextMapGetter,
-    getSpanContext,
-    setSpanContext,
-} from '@opentelemetry/api';
+import { Context, TraceFlags, TextMapPropagator, TextMapSetter, TextMapGetter, trace } from '@opentelemetry/api';
 
 export class DummyPropagation implements TextMapPropagator {
     static TRACE_CONTEXT_KEY = 'x-dummy-trace-id';
@@ -21,11 +13,11 @@ export class DummyPropagation implements TextMapPropagator {
 
         if (!extractedSpanContext.traceId || !extractedSpanContext.spanId) return context;
 
-        return setSpanContext(context, extractedSpanContext);
+        return trace.setSpanContext(context, extractedSpanContext);
     }
 
     inject(context: Context, carrier: unknown, setter: TextMapSetter): void {
-        const spanContext = getSpanContext(context);
+        const spanContext = trace.getSpanContext(context);
         if (!spanContext) return;
 
         setter.set(carrier, DummyPropagation.TRACE_CONTEXT_KEY, spanContext.traceId);

--- a/packages/instrumentation-kafkajs/test/kafkajs.spec.ts
+++ b/packages/instrumentation-kafkajs/test/kafkajs.spec.ts
@@ -75,8 +75,8 @@ describe('instrumentation-kafkajs', () => {
 
     describe('producer', () => {
         const expectKafkaHeadersToMatchSpanContext = (kafkaMessage: Message, span: ReadableSpan) => {
-            expect(kafkaMessage.headers[DummyPropagation.TRACE_CONTEXT_KEY]).toStrictEqual(span.spanContext.traceId);
-            expect(kafkaMessage.headers[DummyPropagation.SPAN_CONTEXT_KEY]).toStrictEqual(span.spanContext.spanId);
+            expect(kafkaMessage.headers[DummyPropagation.TRACE_CONTEXT_KEY]).toStrictEqual(span.spanContext().traceId);
+            expect(kafkaMessage.headers[DummyPropagation.SPAN_CONTEXT_KEY]).toStrictEqual(span.spanContext().spanId);
         };
 
         describe('successful send', () => {
@@ -619,10 +619,10 @@ describe('instrumentation-kafkajs', () => {
                 expect(recvSpan.parentSpanId).toBeUndefined();
                 expect(recvSpan.attributes[SemanticAttributes.MESSAGING_OPERATION]).toStrictEqual('receive');
 
-                expect(msg1Span.parentSpanId).toStrictEqual(recvSpan.spanContext.spanId);
+                expect(msg1Span.parentSpanId).toStrictEqual(recvSpan.spanContext().spanId);
                 expect(msg1Span.attributes[SemanticAttributes.MESSAGING_OPERATION]).toStrictEqual('process');
 
-                expect(msg2Span.parentSpanId).toStrictEqual(recvSpan.spanContext.spanId);
+                expect(msg2Span.parentSpanId).toStrictEqual(recvSpan.spanContext().spanId);
                 expect(msg2Span.attributes[SemanticAttributes.MESSAGING_OPERATION]).toStrictEqual('process');
             });
 
@@ -715,8 +715,8 @@ describe('instrumentation-kafkajs', () => {
             const spans = getTestSpans();
             expect(spans.length).toBe(2);
             const [producerSpan, consumerSpan] = spans;
-            expect(consumerSpan.spanContext.traceId).toStrictEqual(producerSpan.spanContext.traceId);
-            expect(consumerSpan.parentSpanId).toStrictEqual(producerSpan.spanContext.spanId);
+            expect(consumerSpan.spanContext().traceId).toStrictEqual(producerSpan.spanContext().traceId);
+            expect(consumerSpan.parentSpanId).toStrictEqual(producerSpan.spanContext().spanId);
         });
 
         it('context injected in producer is extracted as links in batch consumer', async () => {
@@ -759,15 +759,15 @@ describe('instrumentation-kafkajs', () => {
             const [producerSpan, receivingSpan, processingSpan] = spans;
 
             // processing span should be the child of receiving span and link to relevant producer
-            expect(processingSpan.spanContext.traceId).toStrictEqual(receivingSpan.spanContext.traceId);
-            expect(processingSpan.parentSpanId).toStrictEqual(receivingSpan.spanContext.spanId);
+            expect(processingSpan.spanContext().traceId).toStrictEqual(receivingSpan.spanContext().traceId);
+            expect(processingSpan.parentSpanId).toStrictEqual(receivingSpan.spanContext().spanId);
             expect(processingSpan.links.length).toBe(1);
-            expect(processingSpan.links[0].context.traceId).toStrictEqual(producerSpan.spanContext.traceId);
-            expect(processingSpan.links[0].context.spanId).toStrictEqual(producerSpan.spanContext.spanId);
+            expect(processingSpan.links[0].context.traceId).toStrictEqual(producerSpan.spanContext().traceId);
+            expect(processingSpan.links[0].context.spanId).toStrictEqual(producerSpan.spanContext().spanId);
 
             // receiving span should start a new trace
             expect(receivingSpan.parentSpanId).toBeUndefined();
-            expect(receivingSpan.spanContext.traceId).not.toStrictEqual(producerSpan.spanContext.traceId);
+            expect(receivingSpan.spanContext().traceId).not.toStrictEqual(producerSpan.spanContext().traceId);
         });
     });
 });

--- a/packages/instrumentation-mongoose/package.json
+++ b/packages/instrumentation-mongoose/package.json
@@ -41,12 +41,13 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "dependencies": {
-        "@opentelemetry/api": "^1.0.0-rc.0",
+        "@opentelemetry/api": "^0.20.0",
+        "@opentelemetry/core": "^0.20.0",
         "@opentelemetry/instrumentation": "^0.20.0",
         "@opentelemetry/semantic-conventions": "^0.20.0"
     },
     "devDependencies": {
-        "@opentelemetry/tracing": "^0.19.0",
+        "@opentelemetry/tracing": "^0.20.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/packages/instrumentation-mongoose/package.json
+++ b/packages/instrumentation-mongoose/package.json
@@ -42,8 +42,8 @@
     },
     "dependencies": {
         "@opentelemetry/api": "^1.0.0-rc.0",
-        "@opentelemetry/instrumentation": "^0.19.0",
-        "@opentelemetry/semantic-conventions": "^0.19.0"
+        "@opentelemetry/instrumentation": "^0.20.0",
+        "@opentelemetry/semantic-conventions": "^0.20.0"
     },
     "devDependencies": {
         "@opentelemetry/tracing": "^0.19.0",

--- a/packages/instrumentation-mongoose/package.json
+++ b/packages/instrumentation-mongoose/package.json
@@ -53,7 +53,7 @@
         "mocha": "^8.4.0",
         "mongodb": "^3.6.4",
         "mongoose": "5.11.15",
-        "opentelemetry-instrumentation-mocha": "^0.0.1-rc.0",
+        "opentelemetry-instrumentation-mocha": "^0.0.1-rc.1",
         "opentelemetry-instrumentation-testing-utils": "^0.4.1",
         "ts-node": "^9.1.1",
         "typescript": "^4.0.3"

--- a/packages/instrumentation-mongoose/src/utils.ts
+++ b/packages/instrumentation-mongoose/src/utils.ts
@@ -1,4 +1,4 @@
-import { Tracer, SpanAttributes, SpanStatusCode, context, setSpan, diag, Span, SpanKind } from '@opentelemetry/api';
+import { Tracer, SpanAttributes, SpanStatusCode, context, trace, diag, Span, SpanKind } from '@opentelemetry/api';
 import type { Collection } from 'mongoose';
 import { MongooseResponseCustomAttributesFunction } from './types';
 import { safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
@@ -45,7 +45,7 @@ export function startSpan({
                 [SemanticAttributes.DB_SYSTEM]: 'mongodb',
             },
         },
-        parentSpan ? setSpan(context.active(), parentSpan) : undefined
+        parentSpan ? trace.setSpan(context.active(), parentSpan) : undefined
     );
 }
 

--- a/packages/instrumentation-neo4j/package.json
+++ b/packages/instrumentation-neo4j/package.json
@@ -41,12 +41,12 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "dependencies": {
-        "@opentelemetry/api": "^1.0.0-rc.0",
+        "@opentelemetry/api": "^0.20.0",
         "@opentelemetry/instrumentation": "^0.20.0",
         "@opentelemetry/semantic-conventions": "^0.20.0"
     },
     "devDependencies": {
-        "@opentelemetry/tracing": "^0.19.0",
+        "@opentelemetry/tracing": "^0.20.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/packages/instrumentation-neo4j/package.json
+++ b/packages/instrumentation-neo4j/package.json
@@ -42,8 +42,8 @@
     },
     "dependencies": {
         "@opentelemetry/api": "^1.0.0-rc.0",
-        "@opentelemetry/instrumentation": "^0.19.0",
-        "@opentelemetry/semantic-conventions": "^0.19.0"
+        "@opentelemetry/instrumentation": "^0.20.0",
+        "@opentelemetry/semantic-conventions": "^0.20.0"
     },
     "devDependencies": {
         "@opentelemetry/tracing": "^0.19.0",

--- a/packages/instrumentation-neo4j/package.json
+++ b/packages/instrumentation-neo4j/package.json
@@ -51,7 +51,7 @@
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
         "neo4j-driver": "^4.2.2",
-        "opentelemetry-instrumentation-mocha": "^0.0.1-rc.0",
+        "opentelemetry-instrumentation-mocha": "^0.0.1-rc.1",
         "opentelemetry-instrumentation-testing-utils": "^0.4.1",
         "test-all-versions": "^5.0.1",
         "ts-node": "^9.1.1",

--- a/packages/instrumentation-neo4j/src/neo4j.ts
+++ b/packages/instrumentation-neo4j/src/neo4j.ts
@@ -1,4 +1,4 @@
-import { SpanStatusCode, diag, getSpan, context, SpanKind } from '@opentelemetry/api';
+import { SpanStatusCode, diag, trace, context, SpanKind } from '@opentelemetry/api';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { VERSION } from './version';
 import type * as neo4j from 'neo4j-driver';
@@ -61,7 +61,7 @@ export class Neo4jInstrumentation extends InstrumentationBase<Neo4J> {
         const self = this;
         this._wrap(fileExport.default.prototype, 'run', (originalRun: neo4j.Session['run']) => {
             return function (query: string) {
-                if (self._config?.ignoreOrphanedSpans && !getSpan(context.active())) {
+                if (self._config?.ignoreOrphanedSpans && !trace.getSpan(context.active())) {
                     return originalRun.apply(this, arguments);
                 }
 

--- a/packages/instrumentation-neo4j/test/neo4j.spec.ts
+++ b/packages/instrumentation-neo4j/test/neo4j.spec.ts
@@ -1,6 +1,6 @@
 import 'mocha';
 import expect from 'expect';
-import { context, ROOT_CONTEXT, setSpan, SpanStatusCode, trace } from '@opentelemetry/api';
+import { context, ROOT_CONTEXT, SpanStatusCode, trace } from '@opentelemetry/api';
 import { Neo4jInstrumentation } from '../src';
 import { assertSpan } from './assert';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
@@ -205,7 +205,7 @@ describe('neo4j instrumentation', function () {
             instrumentation.setConfig({ ignoreOrphanedSpans: true });
             instrumentation.enable();
             const parent = trace.getTracerProvider().getTracer('test-tracer').startSpan('main');
-            await context.with(setSpan(context.active(), parent), () =>
+            await context.with(trace.setSpan(context.active(), parent), () =>
                 driver.session().run('CREATE (n:MyLabel) RETURN n')
             );
 

--- a/packages/instrumentation-sequelize/package.json
+++ b/packages/instrumentation-sequelize/package.json
@@ -39,12 +39,13 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "dependencies": {
-        "@opentelemetry/api": "^1.0.0-rc.0",
+        "@opentelemetry/api": "^0.20.0",
+        "@opentelemetry/core": "^0.20.0",
         "@opentelemetry/instrumentation": "^0.20.0",
         "@opentelemetry/semantic-conventions": "^0.20.0"
     },
     "devDependencies": {
-        "@opentelemetry/tracing": "^0.19.0",
+        "@opentelemetry/tracing": "^0.20.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/packages/instrumentation-sequelize/package.json
+++ b/packages/instrumentation-sequelize/package.json
@@ -50,7 +50,7 @@
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
         "mysql2": "^2.2.5",
-        "opentelemetry-instrumentation-mocha": "^0.0.1-rc.0",
+        "opentelemetry-instrumentation-mocha": "^0.0.1-rc.1",
         "opentelemetry-instrumentation-testing-utils": "^0.4.1",
         "pg": "^8.4.2",
         "sequelize": "^5.22.0",

--- a/packages/instrumentation-sequelize/package.json
+++ b/packages/instrumentation-sequelize/package.json
@@ -40,8 +40,8 @@
     },
     "dependencies": {
         "@opentelemetry/api": "^1.0.0-rc.0",
-        "@opentelemetry/instrumentation": "^0.19.0",
-        "@opentelemetry/semantic-conventions": "^0.19.0"
+        "@opentelemetry/instrumentation": "^0.20.0",
+        "@opentelemetry/semantic-conventions": "^0.20.0"
     },
     "devDependencies": {
         "@opentelemetry/tracing": "^0.19.0",

--- a/packages/instrumentation-sequelize/src/sequelize.ts
+++ b/packages/instrumentation-sequelize/src/sequelize.ts
@@ -1,11 +1,4 @@
-import {
-    context,
-    Span,
-    SpanKind,
-    SpanStatusCode,
-    trace,
-    diag,
-} from '@opentelemetry/api';
+import { context, Span, SpanKind, SpanStatusCode, trace, diag } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
 import { NetTransportValues, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import * as sequelize from 'sequelize';

--- a/packages/instrumentation-sequelize/src/sequelize.ts
+++ b/packages/instrumentation-sequelize/src/sequelize.ts
@@ -1,13 +1,12 @@
 import {
     context,
-    setSpan,
     Span,
     SpanKind,
     SpanStatusCode,
-    getSpan,
+    trace,
     diag,
-    suppressInstrumentation,
 } from '@opentelemetry/api';
+import { suppressTracing } from '@opentelemetry/core';
 import { NetTransportValues, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import * as sequelize from 'sequelize';
 import { SequelizeInstrumentationConfig } from './types';
@@ -88,18 +87,18 @@ export class SequelizeInstrumentation extends InstrumentationBase<typeof sequeli
         }
     }
 
-    // run getConnection with suppressInstrumentation, as it might call internally to `databaseVersion` function
+    // run getConnection with suppressTracing, as it might call internally to `databaseVersion` function
     // which calls `query` and create internal span which we don't need to instrument
     private _getConnectionPatch(original: Function) {
         return function (...args: unknown[]) {
-            return context.with(suppressInstrumentation(context.active()), () => original.apply(this, args));
+            return context.with(suppressTracing(context.active()), () => original.apply(this, args));
         };
     }
 
     private _createQueryPatch(original: Function) {
         const self = this;
         return function (sql: any, option: any) {
-            if (self._config?.ignoreOrphanedSpans && !getSpan(context.active())) {
+            if (self._config?.ignoreOrphanedSpans && !trace.getSpan(context.active())) {
                 return original.apply(this, arguments);
             }
 
@@ -141,7 +140,7 @@ export class SequelizeInstrumentation extends InstrumentationBase<typeof sequeli
             });
 
             return context
-                .with(setSpan(context.active(), newSpan), () => original.apply(this, arguments))
+                .with(trace.setSpan(context.active(), newSpan), () => original.apply(this, arguments))
                 .then((response: any) => {
                     if (self._config?.responseHook) {
                         safeExecuteInTheMiddle(

--- a/packages/instrumentation-socket.io/README.md
+++ b/packages/instrumentation-socket.io/README.md
@@ -36,6 +36,14 @@ socket.io instrumentation has few options available to choose from. You can set 
 | `emitHook` | `SocketIoHookFunction` | hook for adding custom attributes before socket.io emits the event |
 | `onHook` | `SocketIoHookFunction` | hook for adding custom attributes before the event listener (callback) is invoked |
 | `traceReserved` | `boolean` | set to true if you want to trace socket.io reserved events (see https://socket.io/docs/v4/emit-cheatsheet/#Reserved-events) |
+| `filterHttpTransport`| `HttpTransportInstrumentationConfig` | set if you want to filter out the HTTP traces when using HTTP polling as the transport (see options below)
+
+`HttpTransportInstrumentationConfig` has a few options available to choose from. You can set the following:
+
+| Options        | Type                                   | Description                                                                                     |
+| -------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `httpInstrumentation`| `HttpInstrumentation` | the instance of HttpInstrumentation you pass to `registerInstrumentations`|
+| `socketPath` | `string` | the socket.io endpoint path (defaults to `/socket.io/`) |
 ---
 
 This extension (and many others) was developed by [Aspecto](https://www.aspecto.io/) with ❤️

--- a/packages/instrumentation-socket.io/README.md
+++ b/packages/instrumentation-socket.io/README.md
@@ -36,7 +36,11 @@ socket.io instrumentation has few options available to choose from. You can set 
 | `emitHook` | `SocketIoHookFunction` | hook for adding custom attributes before socket.io emits the event |
 | `onHook` | `SocketIoHookFunction` | hook for adding custom attributes before the event listener (callback) is invoked |
 | `traceReserved` | `boolean` | set to true if you want to trace socket.io reserved events (see https://socket.io/docs/v4/emit-cheatsheet/#Reserved-events) |
-| `filterHttpTransport`| `HttpTransportInstrumentationConfig` | set if you want to filter out the HTTP traces when using HTTP polling as the transport (see options below)
+| `filterHttpTransport`| `HttpTransportInstrumentationConfig` | set if you want to filter out the HTTP traces when using HTTP polling as the transport (see below)
+
+#### HttpTransportInstrumentationConfig
+If you use `opentelemetry-instrumentation-socket.io` alongside `instrumentation-http`, socket.io might use HTTP polling as the transport method. Therefore, you will see an HTTP span created as the parent of the socket.io span. 
+To filter out those spans; we use HttpTransportInstrumentationConfig.
 
 `HttpTransportInstrumentationConfig` has a few options available to choose from. You can set the following:
 

--- a/packages/instrumentation-socket.io/package.json
+++ b/packages/instrumentation-socket.io/package.json
@@ -48,6 +48,7 @@
     "devDependencies": {
         "@opentelemetry/instrumentation-http": "^0.20.0",
         "@opentelemetry/tracing": "^0.19.0",
+        "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
         "opentelemetry-instrumentation-mocha": "^0.0.1-rc.0",

--- a/packages/instrumentation-socket.io/package.json
+++ b/packages/instrumentation-socket.io/package.json
@@ -41,11 +41,12 @@
     },
     "dependencies": {
         "@opentelemetry/api": "^1.0.0-rc.0",
-        "@opentelemetry/instrumentation": "^0.19.0",
-        "@opentelemetry/semantic-conventions": "^0.19.0",
+        "@opentelemetry/instrumentation": "^0.20.0",
+        "@opentelemetry/semantic-conventions": "^0.20.0",
         "is-promise": "^4.0.0"
     },
     "devDependencies": {
+        "@opentelemetry/instrumentation-http": "^0.20.0",
         "@opentelemetry/tracing": "^0.19.0",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/packages/instrumentation-socket.io/package.json
+++ b/packages/instrumentation-socket.io/package.json
@@ -51,7 +51,7 @@
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
-        "opentelemetry-instrumentation-mocha": "^0.0.1-rc.0",
+        "opentelemetry-instrumentation-mocha": "^0.0.1-rc.1",
         "opentelemetry-instrumentation-testing-utils": "^0.4.1",
         "socket.io": "^4.1.2",
         "socket.io-client": "^4.1.1",

--- a/packages/instrumentation-socket.io/package.json
+++ b/packages/instrumentation-socket.io/package.json
@@ -40,14 +40,14 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "dependencies": {
-        "@opentelemetry/api": "^1.0.0-rc.0",
+        "@opentelemetry/api": "^0.20.0",
         "@opentelemetry/instrumentation": "^0.20.0",
         "@opentelemetry/semantic-conventions": "^0.20.0",
         "is-promise": "^4.0.0"
     },
     "devDependencies": {
         "@opentelemetry/instrumentation-http": "^0.20.0",
-        "@opentelemetry/tracing": "^0.19.0",
+        "@opentelemetry/tracing": "^0.20.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/packages/instrumentation-socket.io/src/socket.io.ts
+++ b/packages/instrumentation-socket.io/src/socket.io.ts
@@ -41,9 +41,6 @@ export class SocketIoInstrumentation extends InstrumentationBase<Io> {
             config.filterHttpTransport.httpInstrumentation.setConfig(httpInstrumentationConfig);
         }
     }
-    setConfig(config: SocketIoInstrumentationConfig) {
-        this._config = Object.assign({}, this._config, config);
-    }
     protected init() {
         const socketInstrumentation = new InstrumentationNodeModuleFile<any>(
             'socket.io/dist/socket.js',

--- a/packages/instrumentation-socket.io/src/socket.io.ts
+++ b/packages/instrumentation-socket.io/src/socket.io.ts
@@ -11,13 +11,8 @@ import {
     MessagingOperationValues,
     MessagingDestinationKindValues,
 } from '@opentelemetry/semantic-conventions';
-import {
-    SocketIoInstrumentationConfig,
-    Io,
-    SocketIoInstrumentationAttributes,
-    defaultSocketIoPath,
-    HttpInstrumentationConfig,
-} from './types';
+import type { HttpInstrumentationConfig } from '@opentelemetry/instrumentation-http';
+import { SocketIoInstrumentationConfig, Io, SocketIoInstrumentationAttributes, defaultSocketIoPath } from './types';
 import { VERSION } from './version';
 import isPromise from 'is-promise';
 

--- a/packages/instrumentation-socket.io/src/socket.io.ts
+++ b/packages/instrumentation-socket.io/src/socket.io.ts
@@ -1,4 +1,4 @@
-import { context, setSpan, Span, SpanKind, SpanStatusCode, diag } from '@opentelemetry/api';
+import { context, trace, Span, SpanKind, SpanStatusCode, diag } from '@opentelemetry/api';
 import {
     InstrumentationBase,
     InstrumentationNodeModuleFile,
@@ -28,7 +28,6 @@ export class SocketIoInstrumentation extends InstrumentationBase<Io> {
 
     constructor(config: SocketIoInstrumentationConfig = {}) {
         super('opentelemetry-instrumentation-socket.io', VERSION, Object.assign({}, config));
-
         if (config.filterHttpTransport) {
             const httpInstrumentationConfig =
                 config.filterHttpTransport.httpInstrumentation.getConfig() as HttpInstrumentationConfig;
@@ -167,7 +166,7 @@ export class SocketIoInstrumentation extends InstrumentationBase<Io> {
                             true
                         );
                     }
-                    return context.with(setSpan(context.active(), span), () =>
+                    return context.with(trace.setSpan(context.active(), span), () =>
                         self.endSpan(() => originalListener.apply(this, arguments), span)
                     );
                 };
@@ -245,7 +244,7 @@ export class SocketIoInstrumentation extends InstrumentationBase<Io> {
                     );
                 }
                 try {
-                    return context.with(setSpan(context.active(), span), () => original.apply(this, arguments));
+                    return context.with(trace.setSpan(context.active(), span), () => original.apply(this, arguments));
                 } catch (error) {
                     span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
                     throw error;

--- a/packages/instrumentation-socket.io/src/types.ts
+++ b/packages/instrumentation-socket.io/src/types.ts
@@ -35,4 +35,3 @@ export interface SocketIoInstrumentationConfig extends InstrumentationConfig {
     filterHttpTransport?: HttpTransportInstrumentationConfig;
 }
 export type Io = typeof io;
-export type { HttpInstrumentationConfig } from '@opentelemetry/instrumentation-http';

--- a/packages/instrumentation-socket.io/src/types.ts
+++ b/packages/instrumentation-socket.io/src/types.ts
@@ -1,6 +1,9 @@
 import { Span } from '@opentelemetry/api';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import type * as io from 'socket.io';
+import type { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
+
+export const defaultSocketIoPath = '/socket.io/';
 
 export const SocketIoInstrumentationAttributes = {
     SOCKET_IO_ROOMS: 'messaging.socket.io.rooms',
@@ -14,12 +17,22 @@ export interface SocketIoHookInfo {
 export interface SocketIoHookFunction {
     (span: Span, hookInfo: SocketIoHookInfo): void;
 }
+
+export interface HttpTransportInstrumentationConfig {
+    /** Set to the instance of `HttpInstrumentation` used for http instrumentation */
+    httpInstrumentation: HttpInstrumentation;
+    /** Set to the path of socket.io endpoint Desalts to `/socket.io/` */
+    socketPath?: string;
+}
 export interface SocketIoInstrumentationConfig extends InstrumentationConfig {
     /** Hook for adding custom attributes before socket.io emits the event */
     emitHook?: SocketIoHookFunction;
     /** Hook for adding custom attributes before the event listener (callback) is invoked */
     onHook?: SocketIoHookFunction;
-    /** Set to true if you want to trace socket.io reserved events (see https://socket.io/docs/v4/emit-cheatsheet/#Reserved-events) */
+    /** Set to `true` if you want to trace socket.io reserved events (see https://socket.io/docs/v4/emit-cheatsheet/#Reserved-events) */
     traceReserved?: boolean;
+    /** Set to `TransportInstrumentationConfig` if you want to filter out socket.io HTTP transport  */
+    filterHttpTransport?: HttpTransportInstrumentationConfig;
 }
 export type Io = typeof io;
+export type { HttpInstrumentationConfig } from '@opentelemetry/instrumentation-http';

--- a/packages/instrumentation-socket.io/test/config.spec.ts
+++ b/packages/instrumentation-socket.io/test/config.spec.ts
@@ -1,21 +1,10 @@
-import { MessagingDestinationKindValues, SemanticAttributes } from '@opentelemetry/semantic-conventions';
-import { ReadableSpan } from '@opentelemetry/tracing';
 import { defaultSocketIoPath, SocketIoInstrumentation, SocketIoInstrumentationAttributes } from '../src';
-import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
-import { getTestSpans } from 'opentelemetry-instrumentation-testing-utils';
 import { HttpInstrumentation, HttpInstrumentationConfig } from '@opentelemetry/instrumentation-http';
-import { AddressInfo } from 'net';
 import expect from 'expect';
-import http from 'http';
-import 'mocha';
-
-const instrumentation = new SocketIoInstrumentation();
-import { Server, Socket } from 'socket.io';
-import { io } from 'socket.io-client';
 
 describe('SocketIoInstrumentationConfig', () => {
     describe('filterHttpTransport', () => {
-        it('add socket.io path to HttpInstrumentationConfig.ignoreIncomingPaths', () => {
+        it('add default socket.io path to HttpInstrumentationConfig.ignoreIncomingPaths', () => {
             const httpInstrumentation = new HttpInstrumentation();
             const socketIoInstrumentation = new SocketIoInstrumentation({
                 filterHttpTransport: {
@@ -25,6 +14,20 @@ describe('SocketIoInstrumentationConfig', () => {
 
             const httpInstrumentationConfig = httpInstrumentation.getConfig() as HttpInstrumentationConfig;
             expect(httpInstrumentationConfig.ignoreIncomingPaths).toContain(defaultSocketIoPath);
+        });
+
+        it('add custom socket.io path to HttpInstrumentationConfig.ignoreIncomingPaths', () => {
+            const path = '/test';
+            const httpInstrumentation = new HttpInstrumentation();
+            const socketIoInstrumentation = new SocketIoInstrumentation({
+                filterHttpTransport: {
+                    httpInstrumentation,
+                    socketPath: path,
+                },
+            });
+
+            const httpInstrumentationConfig = httpInstrumentation.getConfig() as HttpInstrumentationConfig;
+            expect(httpInstrumentationConfig.ignoreIncomingPaths).toContain(path);
         });
     });
 });

--- a/packages/instrumentation-socket.io/test/config.spec.ts
+++ b/packages/instrumentation-socket.io/test/config.spec.ts
@@ -1,0 +1,30 @@
+import { MessagingDestinationKindValues, SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { ReadableSpan } from '@opentelemetry/tracing';
+import { defaultSocketIoPath, SocketIoInstrumentation, SocketIoInstrumentationAttributes } from '../src';
+import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
+import { getTestSpans } from 'opentelemetry-instrumentation-testing-utils';
+import { HttpInstrumentation, HttpInstrumentationConfig } from '@opentelemetry/instrumentation-http';
+import { AddressInfo } from 'net';
+import expect from 'expect';
+import http from 'http';
+import 'mocha';
+
+const instrumentation = new SocketIoInstrumentation();
+import { Server, Socket } from 'socket.io';
+import { io } from 'socket.io-client';
+
+describe('SocketIoInstrumentationConfig', () => {
+    describe('filterHttpTransport', () => {
+        it('add socket.io path to HttpInstrumentationConfig.ignoreIncomingPaths', () => {
+            const httpInstrumentation = new HttpInstrumentation();
+            const socketIoInstrumentation = new SocketIoInstrumentation({
+                filterHttpTransport: {
+                    httpInstrumentation,
+                },
+            });
+
+            const httpInstrumentationConfig = httpInstrumentation.getConfig() as HttpInstrumentationConfig;
+            expect(httpInstrumentationConfig.ignoreIncomingPaths).toContain(defaultSocketIoPath);
+        });
+    });
+});

--- a/packages/instrumentation-socket.io/test/config.spec.ts
+++ b/packages/instrumentation-socket.io/test/config.spec.ts
@@ -1,4 +1,4 @@
-import { defaultSocketIoPath, SocketIoInstrumentation, SocketIoInstrumentationAttributes } from '../src';
+import { defaultSocketIoPath, SocketIoInstrumentation } from '../src';
 import { HttpInstrumentation, HttpInstrumentationConfig } from '@opentelemetry/instrumentation-http';
 import expect from 'expect';
 

--- a/packages/instrumentation-socket.io/test/socket.io.spec.ts
+++ b/packages/instrumentation-socket.io/test/socket.io.spec.ts
@@ -1,6 +1,6 @@
 import { MessagingDestinationKindValues, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { ReadableSpan } from '@opentelemetry/tracing';
-import { SocketIoInstrumentation, SocketIoInstrumentationAttributes } from '../src';
+import { SocketIoInstrumentation, SocketIoInstrumentationAttributes, SocketIoInstrumentationConfig } from '../src';
 import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
 import { getTestSpans } from 'opentelemetry-instrumentation-testing-utils';
 import { AddressInfo } from 'net';
@@ -55,9 +55,10 @@ describe('SocketIoInstrumentation', () => {
         });
 
         it('emit reserved events error is instrumented', () => {
-            instrumentation.setConfig({
+            const config: SocketIoInstrumentationConfig = {
                 traceReserved: true,
-            });
+            };
+            instrumentation.setConfig(config);
             const io = new Server();
             try {
                 io.emit('connect');
@@ -81,12 +82,14 @@ describe('SocketIoInstrumentation', () => {
         });
 
         it('emitHook is called', () => {
-            instrumentation.setConfig({
+            const config: SocketIoInstrumentationConfig = {
                 traceReserved: true,
                 emitHook: (span, hookInfo) => {
                     span.setAttribute('payload', JSON.stringify(hookInfo.payload));
                 },
-            });
+            };
+            instrumentation.setConfig(config);
+
             const io = new Server();
             io.emit('test', 1234);
             expectSpan('/ send', (span) => {
@@ -95,12 +98,12 @@ describe('SocketIoInstrumentation', () => {
         });
 
         it('emitHook error does not effect trace', () => {
-            instrumentation.setConfig({
+            const config: SocketIoInstrumentationConfig = {
                 emitHook: () => {
                     throw new Error('Throwing');
                 },
-            });
-
+            };
+            instrumentation.setConfig(config);
             const io = new Server();
             io.emit('test');
             const spans = getSocketIoSpans();
@@ -108,11 +111,12 @@ describe('SocketIoInstrumentation', () => {
         });
 
         it('onHook is called', (done) => {
-            instrumentation.setConfig({
+            const config: SocketIoInstrumentationConfig = {
                 onHook: (span, hookInfo) => {
                     span.setAttribute('payload', JSON.stringify(hookInfo.payload));
                 },
-            });
+            };
+            instrumentation.setConfig(config);
             const data = {
                 name: 'bob',
                 age: 28,
@@ -144,9 +148,10 @@ describe('SocketIoInstrumentation', () => {
         });
 
         it('traceReserved:true on is instrumented', (done) => {
-            instrumentation.setConfig({
+            const config: SocketIoInstrumentationConfig = {
                 traceReserved: true,
-            });
+            };
+            instrumentation.setConfig(config);
             createServer((sio, port) => {
                 const client = io(`http://localhost:${port}`);
                 sio.on('connection', () => {

--- a/packages/instrumentation-socket.io/test/socket.io.spec.ts
+++ b/packages/instrumentation-socket.io/test/socket.io.spec.ts
@@ -12,7 +12,7 @@ const instrumentation = new SocketIoInstrumentation();
 import { Server, Socket } from 'socket.io';
 import { io } from 'socket.io-client';
 
-describe('socket.io instrumentation', () => {
+describe('SocketIoInstrumentation', () => {
     const getSocketIoSpans = (): ReadableSpan[] =>
         getTestSpans().filter((s) => s.attributes[SemanticAttributes.MESSAGING_SYSTEM] === 'socket.io');
 

--- a/packages/instrumentation-socket.io/tsconfig.json
+++ b/packages/instrumentation-socket.io/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../tsconfig.base.json",
     "compilerOptions": {
         "rootDir": ".",
-        "outDir": "./dist"
+        "outDir": "./dist",
+        "types": ["node", "mocha"],
     }
 }

--- a/packages/instrumentation-socket.io/tsconfig.json
+++ b/packages/instrumentation-socket.io/tsconfig.json
@@ -3,6 +3,6 @@
     "compilerOptions": {
         "rootDir": ".",
         "outDir": "./dist",
-        "types": ["node", "mocha"],
+        "types": ["node", "mocha"]
     }
 }

--- a/packages/instrumentation-testing-utils/package.json
+++ b/packages/instrumentation-testing-utils/package.json
@@ -29,9 +29,9 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "dependencies": {
-        "@opentelemetry/api": "^1.0.0-rc.0",
-        "@opentelemetry/exporter-jaeger": "^0.19.0",
-        "@opentelemetry/node": "^0.19.0",
-        "@opentelemetry/tracing": "^0.19.0"
+        "@opentelemetry/api": "^0.20.0",
+        "@opentelemetry/exporter-jaeger": "^0.20.0",
+        "@opentelemetry/node": "^0.20.0",
+        "@opentelemetry/tracing": "^0.20.0"
     }
 }

--- a/packages/instrumentation-testing-utils/src/index.ts
+++ b/packages/instrumentation-testing-utils/src/index.ts
@@ -1,3 +1,5 @@
+import { Resource } from '@opentelemetry/resources';
+import { ResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { registerInstrumentationTestingProvider } from './otel-default-provider';
 import { resetMemoryExporter } from './otel-provider-api';
 
@@ -23,5 +25,9 @@ export async function mochaGlobalSetup() {
             serviceName = require(process.argv[1] + '/../../../package.json').name;
         } catch {}
     }
-    registerInstrumentationTestingProvider(serviceName);
+    registerInstrumentationTestingProvider({
+        resource: new Resource({
+            [ResourceAttributes.SERVICE_NAME]: serviceName,
+        }),
+    });
 }

--- a/packages/instrumentation-testing-utils/src/otel-default-provider.ts
+++ b/packages/instrumentation-testing-utils/src/otel-default-provider.ts
@@ -13,7 +13,7 @@ export const registerInstrumentationTestingProvider = (
     otelTestingProvider.addSpanProcessor(new SimpleSpanProcessor(getTestMemoryExporter()));
 
     if (process.env.OTEL_EXPORTER_JAEGER_AGENT_HOST) {
-        otelTestingProvider.addSpanProcessor(new SimpleSpanProcessor(new JaegerExporter({ serviceName })));
+        otelTestingProvider.addSpanProcessor(new SimpleSpanProcessor(new JaegerExporter()));
     }
 
     otelTestingProvider.register();

--- a/packages/instrumentation-testing-utils/src/otel-default-provider.ts
+++ b/packages/instrumentation-testing-utils/src/otel-default-provider.ts
@@ -3,10 +3,7 @@ import { NodeTracerProvider, NodeTracerConfig } from '@opentelemetry/node';
 import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/tracing';
 import { getTestMemoryExporter, setTestMemoryExporter } from './otel-provider-api';
 
-export const registerInstrumentationTestingProvider = (
-    serviceName: string,
-    config?: NodeTracerConfig
-): NodeTracerProvider => {
+export const registerInstrumentationTestingProvider = (config?: NodeTracerConfig): NodeTracerProvider => {
     const otelTestingProvider = new NodeTracerProvider(config);
 
     setTestMemoryExporter(new InMemorySpanExporter());

--- a/packages/instrumentation-typeorm/package.json
+++ b/packages/instrumentation-typeorm/package.json
@@ -34,12 +34,12 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "dependencies": {
-        "@opentelemetry/api": "^1.0.0-rc.0",
+        "@opentelemetry/api": "^0.20.0",
         "@opentelemetry/instrumentation": "^0.20.0",
         "@opentelemetry/semantic-conventions": "^0.20.0"
     },
     "devDependencies": {
-        "@opentelemetry/tracing": "^0.19.0",
+        "@opentelemetry/tracing": "^0.20.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/packages/instrumentation-typeorm/package.json
+++ b/packages/instrumentation-typeorm/package.json
@@ -43,7 +43,7 @@
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
-        "opentelemetry-instrumentation-mocha": "^0.0.1-rc.0",
+        "opentelemetry-instrumentation-mocha": "^0.0.1-rc.1",
         "opentelemetry-instrumentation-testing-utils": "^0.4.1",
         "reflect-metadata": "^0.1.13",
         "ts-node": "^9.1.1",

--- a/packages/instrumentation-typeorm/package.json
+++ b/packages/instrumentation-typeorm/package.json
@@ -35,8 +35,8 @@
     },
     "dependencies": {
         "@opentelemetry/api": "^1.0.0-rc.0",
-        "@opentelemetry/instrumentation": "^0.19.0",
-        "@opentelemetry/semantic-conventions": "^0.19.0"
+        "@opentelemetry/instrumentation": "^0.20.0",
+        "@opentelemetry/semantic-conventions": "^0.20.0"
     },
     "devDependencies": {
         "@opentelemetry/tracing": "^0.19.0",

--- a/packages/instrumentation-typeorm/src/typeorm.ts
+++ b/packages/instrumentation-typeorm/src/typeorm.ts
@@ -1,4 +1,4 @@
-import { Span, SpanKind, SpanStatusCode, setSpan, context, diag } from '@opentelemetry/api';
+import { Span, SpanKind, SpanStatusCode, trace, context, diag } from '@opentelemetry/api';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { TypeormInstrumentationConfig } from './types';
 import { getParamNames } from './utils';
@@ -123,7 +123,7 @@ export class TypeormInstrumentation extends InstrumentationBase<typeof typeorm> 
                 });
 
                 try {
-                    const response: Promise<any> = context.with(setSpan(context.active(), newSpan), () =>
+                    const response: Promise<any> = context.with(trace.setSpan(context.active(), newSpan), () =>
                         original.apply(this, arguments)
                     );
                     const resolved = await response;

--- a/packages/propagation-utils/package.json
+++ b/packages/propagation-utils/package.json
@@ -34,11 +34,11 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.0.0-rc.0",
+        "@opentelemetry/api": "^0.20.0",
         "@types/node": "^14.14.8",
         "typescript": "^4.0.3"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0-rc.0"
+        "@opentelemetry/api": "^0.20.0"
     }
 }

--- a/packages/propagation-utils/src/pubsub-propagation.ts
+++ b/packages/propagation-utils/src/pubsub-propagation.ts
@@ -1,4 +1,4 @@
-import { Tracer, SpanKind, Span, Context, Link, getSpanContext, context, setSpan } from '@opentelemetry/api';
+import { Tracer, SpanKind, Span, Context, Link, context, trace } from '@opentelemetry/api';
 
 const START_SPAN_FUNCTION = Symbol('opentelemetry.pubsub-propagation.start_span');
 const END_SPAN_FUNCTION = Symbol('opentelemetry.pubsub-propagation.end_span');
@@ -24,7 +24,7 @@ const patchArrayFunction = (messages: any[], functionName: string, tracer: Trace
             const messageSpan = message?.[START_SPAN_FUNCTION]?.();
             if (!messageSpan) return callback.apply(this, arguments);
 
-            const res = context.with(setSpan(loopContext, messageSpan), () => {
+            const res = context.with(trace.setSpan(loopContext, messageSpan), () => {
                 try {
                     return callback.apply(this, arguments);
                 } catch (err) {
@@ -75,7 +75,7 @@ const startMessagingProcessSpan = <T>(
     processHook?: ProcessHook<T>
 ): Span => {
     const links: Link[] = [];
-    const spanContext = getSpanContext(propagatedContext);
+    const spanContext = trace.getSpanContext(propagatedContext);
     if (spanContext) {
         links.push({
             context: spanContext,


### PR DESCRIPTION
- update otel SDK to v0.20.0
- socket.io instrumentation: ignore HTTP transport traces 