### PR TITLE
fix: use eval('require') in express plugin

### DIFF
--- a/packages/instrumentation-express/src/utils/layer-path.ts
+++ b/packages/instrumentation-express/src/utils/layer-path.ts
@@ -14,7 +14,7 @@ const getLayerPathAlternativeFromFirstArg = (
     pathInput: any,
     options
 ): LayerPathAlternative | LayerPathAlternative[] => {
-    const pathRegexp = require('path-to-regexp');
+    const pathRegexp = eval('require')('path-to-regexp');
 
     if (typeof pathInput === 'string') {
         return {

--- a/packages/instrumentation-express/src/utils/route-context.ts
+++ b/packages/instrumentation-express/src/utils/route-context.ts
@@ -65,7 +65,7 @@ export const createInitialRouteState = (req: express.Request): ExpressConsumedRo
     // at this point, we have the raw http req object, and not the express req.
     // thus, we cannot call req.path
     // we use parseurl(req).pathname which is exactly what express is doing
-    const parseurl = require('parseurl');
+    const parseurl = eval('require')('parseurl');
     const path = parseurl(req).pathname;
     return { resolvedRoute: '', remainingRoute: path, configuredRoute: '', params: {} };
 };


### PR DESCRIPTION
express plugin is using 2 peer dependency - path-to-regexp and parseurl.  
To remove peer dependency warning we set them in lazy require.  
Turns out this breaks when bundling with webpack (do to webpack evaluating all dependencies in advance). 
This workaround fixes the webpack issue.
