### PR TITLE
fix(instrumentation-sequelize): handle sequelize.query() call without options

### DIFF
--- a/packages/instrumentation-sequelize/src/sequelize.ts
+++ b/packages/instrumentation-sequelize/src/sequelize.ts
@@ -97,7 +97,7 @@ export class SequelizeInstrumentation extends InstrumentationBase<typeof sequeli
             }
 
             let statement = sql?.query ? sql.query : sql;
-            let operation = option.type;
+            let operation = option?.type;
 
             if (typeof statement === 'string') {
                 statement = statement.trim();

--- a/packages/instrumentation-sequelize/test/sequelize.spec.ts
+++ b/packages/instrumentation-sequelize/test/sequelize.spec.ts
@@ -225,6 +225,49 @@ describe('instrumentation-sequelize', () => {
                 'SELECT `id`, `firstName`, `createdAt`, `updatedAt` FROM `Users` AS `User`;'
             );
         });
+
+        describe('query is instrumented', () => {
+            it('with options not specified', async () => {
+                try {
+                    await instance.query('SELECT 1 + 1');
+                } catch {
+                    // Do not care about the error
+                }
+                const spans = getSequelizeSpans();
+                expect(spans.length).toBe(1);
+                const attributes = spans[0].attributes;
+
+                expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('SELECT');
+                expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe('SELECT 1 + 1');
+            });
+            it('with type not specified in options', async () => {
+                try {
+                    await instance.query('SELECT 1 + 1', {});
+                } catch {
+                    // Do not care about the error
+                }
+                const spans = getSequelizeSpans();
+                expect(spans.length).toBe(1);
+                const attributes = spans[0].attributes;
+
+                expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('SELECT');
+                expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe('SELECT 1 + 1');
+            });
+
+            it('with type specified in options', async () => {
+                try {
+                    await instance.query('SELECT 1 + 1', { type: sequelize.QueryTypes.RAW });
+                } catch {
+                    // Do not care about the error
+                }
+                const spans = getSequelizeSpans();
+                expect(spans.length).toBe(1);
+                const attributes = spans[0].attributes;
+
+                expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('RAW');
+                expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe('SELECT 1 + 1');
+            });
+        });
     });
 
     describe('sqlite', () => {


### PR DESCRIPTION
`Sequelize#query()` allows to omit second parameter. Instrumentation expects it to be present when getting the query type. This seems to be a typo as query options are expected to be nullable later in code.

Before the change any query without options will fail (e.g. Nest.js healthcheck [does so](https://github.com/nestjs/terminus/blob/f813fed40f065f747d5f9be65045296e5cc14aa8/lib/health-indicator/database/sequelize.health.ts#L79)).