### PR TITLE
chore: upgrade to opentelemetry 0.22.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The instrumentations in this repo are:
 - strictly complies with [open telemetry semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions)
 - up to date with latest SDK version
 
-**Compatible with [SDK v0.21.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v0.21.0)**
+**Compatible with [SDK v0.22.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v0.22.0)**
 ## Instrumentations
 | Instrumentation Package | Instrumented Lib | NPM |
 | --- | --- | --- |
@@ -56,6 +56,7 @@ The instrumentations in this repo are:
 
 | Instrumentations Version | OpenTelemetry Version |
 | --- | --- |
+| 0.22.x | 0.22.0 |
 | 0.21.x | 0.21.0 |
 | 0.5.x | 0.20.0 |
 | 0.4.x | 0.19.0 |

--- a/detectors/node/resource-detector-deployment/package.json
+++ b/detectors/node/resource-detector-deployment/package.json
@@ -44,7 +44,7 @@
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
-        "opentelemetry-instrumentation-mocha": "0.0.1-rc.2",
+        "opentelemetry-instrumentation-mocha": "0.0.1-rc.3",
         "ts-node": "^9.1.1",
         "typescript": "^4.0.5"
     },

--- a/detectors/node/resource-detector-deployment/package.json
+++ b/detectors/node/resource-detector-deployment/package.json
@@ -32,15 +32,15 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^0.21.0"
+        "@opentelemetry/api": "^1.0.0"
     },
     "dependencies": {
-        "@opentelemetry/resources": "^0.21.0",
-        "@opentelemetry/semantic-conventions": "^0.21.0",
+        "@opentelemetry/resources": "^0.22.0",
+        "@opentelemetry/semantic-conventions": "^0.22.0",
         "opentelemetry-resource-detector-sync-api": "^0.21.0"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^0.21.0",
+        "@opentelemetry/api": "^1.0.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/detectors/node/resource-detector-git/package.json
+++ b/detectors/node/resource-detector-git/package.json
@@ -46,7 +46,7 @@
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
-        "opentelemetry-instrumentation-mocha": "0.0.1-rc.2",
+        "opentelemetry-instrumentation-mocha": "0.0.1-rc.3",
         "sinon": "^11.1.1",
         "ts-node": "^9.1.1",
         "typescript": "^4.0.5"

--- a/detectors/node/resource-detector-git/package.json
+++ b/detectors/node/resource-detector-git/package.json
@@ -33,16 +33,16 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^0.21.0"
+        "@opentelemetry/api": "^1.0.0"
     },
     "dependencies": {
-        "@opentelemetry/resources": "^0.21.0",
-        "@opentelemetry/semantic-conventions": "^0.21.0",
+        "@opentelemetry/resources": "^0.22.0",
+        "@opentelemetry/semantic-conventions": "^0.22.0",
         "opentelemetry-resource-detector-sync-api": "^0.21.0",
         "uuid": "^8.3.2"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^0.21.0",
+        "@opentelemetry/api": "^1.0.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/detectors/node/resource-detector-service/package.json
+++ b/detectors/node/resource-detector-service/package.json
@@ -45,7 +45,7 @@
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
-        "opentelemetry-instrumentation-mocha": "0.0.1-rc.2",
+        "opentelemetry-instrumentation-mocha": "0.0.1-rc.3",
         "ts-node": "^9.1.1",
         "typescript": "^4.0.5"
     },

--- a/detectors/node/resource-detector-service/package.json
+++ b/detectors/node/resource-detector-service/package.json
@@ -32,16 +32,16 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^0.21.0"
+        "@opentelemetry/api": "^1.0.0"
     },
     "dependencies": {
-        "@opentelemetry/resources": "^0.21.0",
-        "@opentelemetry/semantic-conventions": "^0.21.0",
+        "@opentelemetry/resources": "^0.22.0",
+        "@opentelemetry/semantic-conventions": "^0.22.0",
         "opentelemetry-resource-detector-sync-api": "^0.21.0",
         "uuid": "^8.3.2"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^0.21.0",
+        "@opentelemetry/api": "^1.0.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/detectors/resource-detector-sync-api/package.json
+++ b/detectors/resource-detector-sync-api/package.json
@@ -29,10 +29,10 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^0.21.0"
+        "@opentelemetry/api": "^1.0.0"
     },
     "dependencies": {
-        "@opentelemetry/resources": "^0.21.0"
+        "@opentelemetry/resources": "^0.22.0"
     },
     "devDependencies": {
         "ts-node": "^9.1.1",

--- a/packages/instrumentation-amqplib/package.json
+++ b/packages/instrumentation-amqplib/package.json
@@ -37,15 +37,15 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^0.21.0"
+        "@opentelemetry/api": "^1.0.0"
     },
     "dependencies": {
-        "@opentelemetry/instrumentation": "^0.21.0",
-        "@opentelemetry/semantic-conventions": "^0.21.0"
+        "@opentelemetry/instrumentation": "^0.22.0",
+        "@opentelemetry/semantic-conventions": "^0.22.0"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^0.21.0",
-        "@opentelemetry/core": "^0.21.0",
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/core": "^0.22.0",
         "@types/amqplib": "^0.5.17",
         "@types/lodash": "^4.14.168",
         "@types/mocha": "^8.2.2",

--- a/packages/instrumentation-amqplib/package.json
+++ b/packages/instrumentation-amqplib/package.json
@@ -54,7 +54,7 @@
         "expect": "^26.6.2",
         "lodash": "^4.17.21",
         "mocha": "^8.4.0",
-        "opentelemetry-instrumentation-mocha": "0.0.1-rc.2",
+        "opentelemetry-instrumentation-mocha": "0.0.1-rc.3",
         "opentelemetry-instrumentation-testing-utils": "^0.21.0",
         "sinon": "^9.2.4",
         "test-all-versions": "^5.0.1",

--- a/packages/instrumentation-aws-sdk/package.json
+++ b/packages/instrumentation-aws-sdk/package.json
@@ -35,20 +35,20 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^0.21.0"
+        "@opentelemetry/api": "^1.0.0"
     },
     "dependencies": {
-        "@opentelemetry/core": "^0.21.0",
-        "@opentelemetry/instrumentation": "^0.21.0",
-        "@opentelemetry/semantic-conventions": "^0.21.0",
+        "@opentelemetry/core": "^0.22.0",
+        "@opentelemetry/instrumentation": "^0.22.0",
+        "@opentelemetry/semantic-conventions": "^0.22.0",
         "opentelemetry-propagation-utils": "^0.21.0"
     },
     "devDependencies": {
         "@aws-sdk/client-s3": "3.13.1",
         "@aws-sdk/client-sqs": "3.13.1",
         "@aws-sdk/types": "3.13.1",
-        "@opentelemetry/api": "^0.21.0",
-        "@opentelemetry/tracing": "^0.21.0",
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/tracing": "^0.22.0",
         "@types/mocha": "^8.2.2",
         "aws-sdk": "^2.780.0",
         "expect": "^26.6.2",

--- a/packages/instrumentation-aws-sdk/package.json
+++ b/packages/instrumentation-aws-sdk/package.json
@@ -54,7 +54,7 @@
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
         "nock": "^13.0.11",
-        "opentelemetry-instrumentation-mocha": "0.0.1-rc.2",
+        "opentelemetry-instrumentation-mocha": "0.0.1-rc.3",
         "opentelemetry-instrumentation-testing-utils": "^0.21.0",
         "test-all-versions": "^5.0.1",
         "ts-node": "^9.1.1",

--- a/packages/instrumentation-elasticsearch/package.json
+++ b/packages/instrumentation-elasticsearch/package.json
@@ -41,16 +41,16 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^0.21.0"
+        "@opentelemetry/api": "^1.0.0"
     },
     "dependencies": {
-        "@opentelemetry/core": "^0.21.0",
-        "@opentelemetry/instrumentation": "^0.21.0",
-        "@opentelemetry/semantic-conventions": "^0.21.0"
+        "@opentelemetry/core": "^0.22.0",
+        "@opentelemetry/instrumentation": "^0.22.0",
+        "@opentelemetry/semantic-conventions": "^0.22.0"
     },
     "devDependencies": {
         "@elastic/elasticsearch": "^7.8.0",
-        "@opentelemetry/api": "^0.21.0",
+        "@opentelemetry/api": "^1.0.0",
         "@types/chai": "^4.2.15",
         "@types/mocha": "^8.2.2",
         "chai": "^4.3.0",

--- a/packages/instrumentation-elasticsearch/package.json
+++ b/packages/instrumentation-elasticsearch/package.json
@@ -57,7 +57,7 @@
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
         "nock": "^13.0.9",
-        "opentelemetry-instrumentation-mocha": "0.0.1-rc.2",
+        "opentelemetry-instrumentation-mocha": "0.0.1-rc.3",
         "opentelemetry-instrumentation-testing-utils": "^0.21.0",
         "sinon": "^9.2.4",
         "test-all-versions": "^5.0.1",

--- a/packages/instrumentation-express/package.json
+++ b/packages/instrumentation-express/package.json
@@ -51,7 +51,7 @@
         "expect": "^26.6.2",
         "express": "4.17.1",
         "mocha": "^8.4.0",
-        "opentelemetry-instrumentation-mocha": "0.0.1-rc.2",
+        "opentelemetry-instrumentation-mocha": "0.0.1-rc.3",
         "opentelemetry-instrumentation-testing-utils": "^0.21.0",
         "test-all-versions": "^5.0.1"
     },

--- a/packages/instrumentation-express/package.json
+++ b/packages/instrumentation-express/package.json
@@ -31,19 +31,19 @@
         "access": "public"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^0.21.0"
+        "@opentelemetry/api": "^1.0.0"
     },
     "dependencies": {
-        "@opentelemetry/core": "^0.21.0",
-        "@opentelemetry/instrumentation": "^0.21.0",
-        "@opentelemetry/semantic-conventions": "^0.21.0",
+        "@opentelemetry/core": "^0.22.0",
+        "@opentelemetry/instrumentation": "^0.22.0",
+        "@opentelemetry/semantic-conventions": "^0.22.0",
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^0.21.0",
-        "@opentelemetry/instrumentation-http": "^0.21.0",
-        "@opentelemetry/tracing": "^0.21.0",
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/instrumentation-http": "^0.22.0",
+        "@opentelemetry/tracing": "^0.22.0",
         "@types/express": "4.17.8",
         "@types/mocha": "^8.2.2",
         "axios": "0.21.1",

--- a/packages/instrumentation-express/test/opentelemetry-express-layers.spec.ts
+++ b/packages/instrumentation-express/test/opentelemetry-express-layers.spec.ts
@@ -673,7 +673,7 @@ describe('opentelemetry-express-layers', () => {
             it('two sibling routes, first is calling res.end()', async () => {
                 app.get('/:firstRouteParam', resEndMiddleware);
                 app.get('/:secondRouteParam', (_req: express.Request, _res: express.Response) => {
-                  throw new Error('should not be invoked');
+                    throw new Error('should not be invoked');
                 });
                 const s = await sendRequest('/foo');
                 expectRouteAttributes(s, '/:firstRouteParam', '/:firstRouteParam', {

--- a/packages/instrumentation-express/test/opentelemetry-express-layers.spec.ts
+++ b/packages/instrumentation-express/test/opentelemetry-express-layers.spec.ts
@@ -672,8 +672,8 @@ describe('opentelemetry-express-layers', () => {
         describe('multiple routes', () => {
             it('two sibling routes, first is calling res.end()', async () => {
                 app.get('/:firstRouteParam', resEndMiddleware);
-                app.get('/:secondRouteParam', (req, res, next) => {
-                    throw Error('should not be invoked');
+                app.get('/:secondRouteParam', (_req: express.Request, _res: express.Response) => {
+                  throw new Error('should not be invoked');
                 });
                 const s = await sendRequest('/foo');
                 expectRouteAttributes(s, '/:firstRouteParam', '/:firstRouteParam', {

--- a/packages/instrumentation-kafkajs/package.json
+++ b/packages/instrumentation-kafkajs/package.json
@@ -34,15 +34,15 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^0.21.0"
+        "@opentelemetry/api": "^1.0.0"
     },
     "dependencies": {
-        "@opentelemetry/instrumentation": "^0.21.0",
-        "@opentelemetry/semantic-conventions": "^0.21.0"
+        "@opentelemetry/instrumentation": "^0.22.0",
+        "@opentelemetry/semantic-conventions": "^0.22.0"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^0.21.0",
-        "@opentelemetry/tracing": "^0.21.0",
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/tracing": "^0.22.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "kafkajs": "^1.12.0",

--- a/packages/instrumentation-kafkajs/package.json
+++ b/packages/instrumentation-kafkajs/package.json
@@ -47,7 +47,7 @@
         "expect": "^26.6.2",
         "kafkajs": "^1.12.0",
         "mocha": "^8.4.0",
-        "opentelemetry-instrumentation-mocha": "0.0.1-rc.2",
+        "opentelemetry-instrumentation-mocha": "0.0.1-rc.3",
         "opentelemetry-instrumentation-testing-utils": "^0.21.0",
         "ts-node": "^9.1.1",
         "typescript": "^3.9.5"

--- a/packages/instrumentation-mongoose/package.json
+++ b/packages/instrumentation-mongoose/package.json
@@ -41,16 +41,16 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^0.21.0"
+        "@opentelemetry/api": "^1.0.0"
     },
     "dependencies": {
-        "@opentelemetry/core": "^0.21.0",
-        "@opentelemetry/instrumentation": "^0.21.0",
-        "@opentelemetry/semantic-conventions": "^0.21.0"
+        "@opentelemetry/core": "^0.22.0",
+        "@opentelemetry/instrumentation": "^0.22.0",
+        "@opentelemetry/semantic-conventions": "^0.22.0"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^0.21.0",
-        "@opentelemetry/tracing": "^0.21.0",
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/tracing": "^0.22.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/packages/instrumentation-mongoose/package.json
+++ b/packages/instrumentation-mongoose/package.json
@@ -56,7 +56,7 @@
         "mocha": "^8.4.0",
         "mongodb": "^3.6.4",
         "mongoose": "5.11.15",
-        "opentelemetry-instrumentation-mocha": "0.0.1-rc.2",
+        "opentelemetry-instrumentation-mocha": "0.0.1-rc.3",
         "opentelemetry-instrumentation-testing-utils": "^0.21.0",
         "ts-node": "^9.1.1",
         "typescript": "^4.0.3"

--- a/packages/instrumentation-neo4j/package.json
+++ b/packages/instrumentation-neo4j/package.json
@@ -54,7 +54,7 @@
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
         "neo4j-driver": "^4.2.2",
-        "opentelemetry-instrumentation-mocha": "0.0.1-rc.2",
+        "opentelemetry-instrumentation-mocha": "0.0.1-rc.3",
         "opentelemetry-instrumentation-testing-utils": "^0.21.0",
         "test-all-versions": "^5.0.1",
         "ts-node": "^9.1.1",

--- a/packages/instrumentation-neo4j/package.json
+++ b/packages/instrumentation-neo4j/package.json
@@ -41,15 +41,15 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^0.21.0"
+        "@opentelemetry/api": "^1.0.0"
     },
     "dependencies": {
-        "@opentelemetry/instrumentation": "^0.21.0",
-        "@opentelemetry/semantic-conventions": "^0.21.0"
+        "@opentelemetry/instrumentation": "^0.22.0",
+        "@opentelemetry/semantic-conventions": "^0.22.0"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^0.21.0",
-        "@opentelemetry/tracing": "^0.21.0",
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/tracing": "^0.22.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/packages/instrumentation-sequelize/package.json
+++ b/packages/instrumentation-sequelize/package.json
@@ -53,7 +53,7 @@
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
         "mysql2": "^2.2.5",
-        "opentelemetry-instrumentation-mocha": "0.0.1-rc.2",
+        "opentelemetry-instrumentation-mocha": "0.0.1-rc.3",
         "opentelemetry-instrumentation-testing-utils": "^0.21.0",
         "pg": "^8.4.2",
         "sequelize": "^5.22.0",

--- a/packages/instrumentation-sequelize/package.json
+++ b/packages/instrumentation-sequelize/package.json
@@ -39,16 +39,16 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^0.21.0"
+        "@opentelemetry/api": "^1.0.0"
     },
     "dependencies": {
-        "@opentelemetry/core": "^0.21.0",
-        "@opentelemetry/instrumentation": "^0.21.0",
-        "@opentelemetry/semantic-conventions": "^0.21.0"
+        "@opentelemetry/core": "^0.22.0",
+        "@opentelemetry/instrumentation": "^0.22.0",
+        "@opentelemetry/semantic-conventions": "^0.22.0"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^0.21.0",
-        "@opentelemetry/tracing": "^0.21.0",
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/tracing": "^0.22.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/packages/instrumentation-socket.io/package.json
+++ b/packages/instrumentation-socket.io/package.json
@@ -40,17 +40,17 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^0.21.0"
+        "@opentelemetry/api": "^1.0.0"
     },
     "dependencies": {
-        "@opentelemetry/instrumentation": "^0.21.0",
-        "@opentelemetry/semantic-conventions": "^0.21.0",
+        "@opentelemetry/instrumentation": "^0.22.0",
+        "@opentelemetry/semantic-conventions": "^0.22.0",
         "is-promise": "^4.0.0"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^0.21.0",
-        "@opentelemetry/instrumentation-http": "^0.21.0",
-        "@opentelemetry/tracing": "^0.21.0",
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/instrumentation-http": "^0.22.0",
+        "@opentelemetry/tracing": "^0.22.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/packages/instrumentation-socket.io/package.json
+++ b/packages/instrumentation-socket.io/package.json
@@ -54,7 +54,7 @@
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
-        "opentelemetry-instrumentation-mocha": "0.0.1-rc.2",
+        "opentelemetry-instrumentation-mocha": "0.0.1-rc.3",
         "opentelemetry-instrumentation-testing-utils": "^0.21.0",
         "socket.io": "^4.1.2",
         "socket.io-client": "^4.1.1",

--- a/packages/instrumentation-testing-utils/package.json
+++ b/packages/instrumentation-testing-utils/package.json
@@ -29,14 +29,14 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^0.21.0"
+        "@opentelemetry/api": "^1.0.0"
     },
     "dependencies": {
-        "@opentelemetry/exporter-jaeger": "^0.21.0",
-        "@opentelemetry/node": "^0.21.0",
-        "@opentelemetry/tracing": "^0.21.0"
+        "@opentelemetry/exporter-jaeger": "^0.22.0",
+        "@opentelemetry/node": "^0.22.0",
+        "@opentelemetry/tracing": "^0.22.0"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^0.21.0"
+        "@opentelemetry/api": "^1.0.0"
     }
 }

--- a/packages/instrumentation-typeorm/package.json
+++ b/packages/instrumentation-typeorm/package.json
@@ -35,17 +35,17 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^0.21.0"
+        "@opentelemetry/api": "^1.0.0"
     },
     "dependencies": {
-        "@opentelemetry/core": "^0.21.0",
-        "@opentelemetry/instrumentation": "^0.21.0",
-        "@opentelemetry/semantic-conventions": "^0.21.0",
+        "@opentelemetry/core": "^0.22.0",
+        "@opentelemetry/instrumentation": "^0.22.0",
+        "@opentelemetry/semantic-conventions": "^0.22.0",
         "is-promise": "^4.0.0"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^0.21.0",
-        "@opentelemetry/tracing": "^0.21.0",
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/tracing": "^0.22.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/packages/instrumentation-typeorm/package.json
+++ b/packages/instrumentation-typeorm/package.json
@@ -49,7 +49,7 @@
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
-        "opentelemetry-instrumentation-mocha": "0.0.1-rc.2",
+        "opentelemetry-instrumentation-mocha": "0.0.1-rc.3",
         "opentelemetry-instrumentation-testing-utils": "^0.21.0",
         "reflect-metadata": "^0.1.13",
         "sqlite3": "^5.0.2",

--- a/packages/propagation-utils/package.json
+++ b/packages/propagation-utils/package.json
@@ -34,11 +34,11 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^0.21.0",
+        "@opentelemetry/api": "^1.0.0",
         "@types/node": "^14.14.8",
         "typescript": "^4.0.3"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^0.21.0"
+        "@opentelemetry/api": "^1.0.0"
     }
 }


### PR DESCRIPTION
Upgrade to OpenTelemetry 0.22 which itself depends on `@opentelemetry/api` `1.0.0`