### PR TITLE
Prepare for v2 support

### DIFF
--- a/packages/instrumentation-socket.io/test/socket.io.spec.ts
+++ b/packages/instrumentation-socket.io/test/socket.io.spec.ts
@@ -112,7 +112,9 @@ describe('SocketIoInstrumentation', () => {
                                 (span) => {
                                     try {
                                         expect(span.kind).toEqual(SpanKind.CONSUMER);
-                                        expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('socket.io');
+                                        expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual(
+                                            'socket.io'
+                                        );
                                         expect(span.attributes['payload']).toEqual([data]);
                                         done();
                                     } catch (e) {
@@ -165,7 +167,9 @@ describe('SocketIoInstrumentation', () => {
                                 (span) => {
                                     try {
                                         expect(span.kind).toEqual(SpanKind.CONSUMER);
-                                        expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('socket.io');
+                                        expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual(
+                                            'socket.io'
+                                        );
                                         done();
                                     } catch (e) {
                                         done(e);
@@ -250,7 +254,9 @@ describe('SocketIoInstrumentation', () => {
                                 (span) => {
                                     try {
                                         expect(span.kind).toEqual(SpanKind.CONSUMER);
-                                        expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('socket.io');
+                                        expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual(
+                                            'socket.io'
+                                        );
                                         expect(span.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(
                                             '/testing'
                                         );

--- a/packages/instrumentation-socket.io/test/socket.io.spec.ts
+++ b/packages/instrumentation-socket.io/test/socket.io.spec.ts
@@ -123,10 +123,14 @@ describe('SocketIoInstrumentation', () => {
                             expectSpan(
                                 'test_reply receive',
                                 (span) => {
-                                    expect(span.kind).toEqual(SpanKind.CONSUMER);
-                                    expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('socket.io');
-                                    expect(span.attributes['payload']).toEqual(JSON.stringify([data]));
-                                    done();
+                                    try {
+                                        expect(span.kind).toEqual(SpanKind.CONSUMER);
+                                        expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('socket.io');
+                                        expect(span.attributes['payload']).toEqual([data]);
+                                        done();
+                                    } catch (e) {
+                                        done(e);
+                                    }
                                 },
                                 3
                             );
@@ -172,9 +176,13 @@ describe('SocketIoInstrumentation', () => {
                             expectSpan(
                                 'test_reply receive',
                                 (span) => {
-                                    expect(span.kind).toEqual(SpanKind.CONSUMER);
-                                    expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('socket.io');
-                                    done();
+                                    try {
+                                        expect(span.kind).toEqual(SpanKind.CONSUMER);
+                                        expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('socket.io');
+                                        done();
+                                    } catch (e) {
+                                        done(e);
+                                    }
                                 },
                                 3
                             );
@@ -253,12 +261,16 @@ describe('SocketIoInstrumentation', () => {
                             expectSpan(
                                 '/testing test_reply receive',
                                 (span) => {
-                                    expect(span.kind).toEqual(SpanKind.CONSUMER);
-                                    expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('socket.io');
-                                    expect(span.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(
-                                        '/testing'
-                                    );
-                                    done();
+                                    try {
+                                        expect(span.kind).toEqual(SpanKind.CONSUMER);
+                                        expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('socket.io');
+                                        expect(span.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(
+                                            '/testing'
+                                        );
+                                        done();
+                                    } catch (e) {
+                                        done(e);
+                                    }
                                 },
                                 2
                             );
@@ -278,9 +290,13 @@ describe('SocketIoInstrumentation', () => {
                     client.close();
                     sio.close();
                     expectSpan(`/[${socket.id}] send`, (span) => {
-                        expect(span.kind).toEqual(SpanKind.PRODUCER);
-                        expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('socket.io');
-                        done();
+                        try {
+                            expect(span.kind).toEqual(SpanKind.PRODUCER);
+                            expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('socket.io');
+                            done();
+                        } catch (e) {
+                            done(e);
+                        }
                     });
                 });
             });

--- a/packages/instrumentation-socket.io/test/socket.io.spec.ts
+++ b/packages/instrumentation-socket.io/test/socket.io.spec.ts
@@ -115,7 +115,7 @@ describe('SocketIoInstrumentation', () => {
                                         expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual(
                                             'socket.io'
                                         );
-                                        expect(span.attributes['payload']).toEqual([data]);
+                                        expect(span.attributes['payload']).toEqual(JSON.stringify([data]));
                                         done();
                                     } catch (e) {
                                         done(e);

--- a/packages/instrumentation-socket.io/test/socket.io.spec.ts
+++ b/packages/instrumentation-socket.io/test/socket.io.spec.ts
@@ -1,19 +1,14 @@
 import { MessagingDestinationKindValues, SemanticAttributes } from '@opentelemetry/semantic-conventions';
-import { ReadableSpan } from '@opentelemetry/tracing';
 import { SocketIoInstrumentation, SocketIoInstrumentationAttributes, SocketIoInstrumentationConfig } from '../src';
 import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
-import { getTestSpans } from 'opentelemetry-instrumentation-testing-utils';
 import expect from 'expect';
 import 'mocha';
 
 const instrumentation = new SocketIoInstrumentation();
 import { Server, Socket } from 'socket.io';
-import { createServer, createServerInstance, io } from './utils';
+import { createServer, createServerInstance, io, getSocketIoSpans, expectSpan } from './utils';
 
 describe('SocketIoInstrumentation', () => {
-    const getSocketIoSpans = (): ReadableSpan[] =>
-        getTestSpans().filter((s) => s.attributes[SemanticAttributes.MESSAGING_SYSTEM] === 'socket.io');
-
     beforeEach(() => {
         instrumentation.enable();
     });
@@ -21,14 +16,6 @@ describe('SocketIoInstrumentation', () => {
     afterEach(() => {
         instrumentation.disable();
     });
-
-    const expectSpan = (spanName: string, callback?: (span: ReadableSpan) => void, spanCount?: number) => {
-        const spans = getSocketIoSpans();
-        expect(spans.length).toEqual(spanCount || 1);
-        const span = spans.find((s) => s.name === spanName);
-        expect(span).toBeDefined();
-        callback(span);
-    };
 
     describe('Server', () => {
         it('emit is instrumented', () => {

--- a/packages/instrumentation-socket.io/test/socket.io.spec.ts
+++ b/packages/instrumentation-socket.io/test/socket.io.spec.ts
@@ -112,16 +112,16 @@ describe('SocketIoInstrumentation', () => {
             };
             createServer((sio, port) => {
                 const client = io(`http://localhost:${port}`);
-                client.on('ping', () => client.emit('pong', data));
+                client.on('test', () => client.emit('test_reply', data));
                 sio.on('connection', (socket: Socket) => {
-                    socket.emit('ping');
-                    socket.on('pong', (data) => {
+                    socket.emit('test');
+                    socket.on('test_reply', (data) => {
                         client.close();
                         sio.close();
                         //trace is created after the listener method is completed
                         setTimeout(() => {
                             expectSpan(
-                                'pong receive',
+                                'test_reply receive',
                                 (span) => {
                                     expect(span.kind).toEqual(SpanKind.CONSUMER);
                                     expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('socket.io');
@@ -161,16 +161,16 @@ describe('SocketIoInstrumentation', () => {
         it('on is instrumented', (done) => {
             createServer((sio, port) => {
                 const client = io(`http://localhost:${port}`);
-                client.on('ping', () => client.emit('pong'));
+                client.on('test', () => client.emit('test_reply'));
                 sio.on('connection', (socket: Socket) => {
-                    socket.emit('ping');
-                    socket.on('pong', () => {
+                    socket.emit('test');
+                    socket.on('test_reply', () => {
                         client.close();
                         sio.close();
                         //trace is created after the listener method is completed
                         setTimeout(() => {
                             expectSpan(
-                                'pong receive',
+                                'test_reply receive',
                                 (span) => {
                                     expect(span.kind).toEqual(SpanKind.CONSUMER);
                                     expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('socket.io');
@@ -242,16 +242,16 @@ describe('SocketIoInstrumentation', () => {
             createServer((sio, port) => {
                 const namespace = sio.of('/testing');
                 const client = io(`http://localhost:${port}/testing`);
-                client.on('ping', () => client.emit('pong'));
+                client.on('test', () => client.emit('test_reply'));
                 namespace.on('connection', (socket: Socket) => {
-                    socket.emit('ping');
-                    socket.on('pong', () => {
+                    socket.emit('test');
+                    socket.on('test_reply', () => {
                         client.close();
                         sio.close();
                         //trace is created after the listener method is completed
                         setTimeout(() => {
                             expectSpan(
-                                '/testing pong receive',
+                                '/testing test_reply receive',
                                 (span) => {
                                     expect(span.kind).toEqual(SpanKind.CONSUMER);
                                     expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('socket.io');
@@ -274,7 +274,7 @@ describe('SocketIoInstrumentation', () => {
             createServer((sio, port) => {
                 const client = io(`http://localhost:${port}`);
                 sio.on('connection', (socket: Socket) => {
-                    socket.emit('ping');
+                    socket.emit('test');
                     client.close();
                     sio.close();
                     expectSpan(`/[${socket.id}] send`, (span) => {

--- a/packages/instrumentation-socket.io/test/utils.ts
+++ b/packages/instrumentation-socket.io/test/utils.ts
@@ -1,0 +1,28 @@
+import { AddressInfo } from 'net';
+import http from 'http';
+
+import { strict as assert} from 'assert';
+import { Server, Socket } from 'socket.io';
+import socketIo from 'socket.io';
+import * as ioClient from 'socket.io-client';
+
+export const io = (ioClient.io || (ioClient as any).default) as typeof ioClient.io;
+const version = require('../node_modules/socket.io/package.json').version;
+
+assert.equal(typeof version, 'string');
+
+export const createServer = (callback: (server: Server, port: number) => void) => {
+    const server = http.createServer();
+    const sio = createServerInstance(server);
+    server.listen(0, () => {
+        const port = (server.address() as AddressInfo).port;
+        callback(sio, port);
+    });
+};
+
+export const createServerInstance = (server?: http.Server) => {
+    if (version && /^2\./.test(version)) {
+        return (socketIo as any)(server);
+    }
+    return new Server(server);
+};

--- a/packages/instrumentation-socket.io/test/utils.ts
+++ b/packages/instrumentation-socket.io/test/utils.ts
@@ -1,4 +1,4 @@
-import { strict as assert} from 'assert';
+import { strict as assert } from 'assert';
 import http from 'http';
 import { AddressInfo } from 'net';
 
@@ -31,7 +31,6 @@ export const createServerInstance = (server?: http.Server) => {
     }
     return new Server(server);
 };
-
 
 export const getSocketIoSpans = (): ReadableSpan[] =>
     getTestSpans().filter((s) => s.attributes[SemanticAttributes.MESSAGING_SYSTEM] === 'socket.io');


### PR DESCRIPTION
The oldest current version supported is from 8 months ago. I'd like to support at least v2(2.0.0 released in 2017, latest 2.x in 2021). However, the initialization is a bit different for that. This PR prepares a few of the things without actually adding support for v2 or changing any of the behaviour to make the next PR more concise and easier to follow.

Check the commits for details, but:

* supports initialization in the way v2 does it - version checking is a bit hacky TBH, I'm open to a better way if you have any preferences;
* catches async errors in tests(stumbled upon those implementing v2 support);
* renames events "ping" and "pong" in tests since those are internally used for heartbeats in v2.

Look out for any linting/formatting inconsistencies, because I didn't find a way to automatically apply those(I see GHA job for prettier but running default prettier gave me tons of markdown changes as well - just isolate to `ts` files?).