### PR TITLE
feat: add support for v2

### DIFF
--- a/packages/instrumentation-socket.io/.tav.yml
+++ b/packages/instrumentation-socket.io/.tav.yml
@@ -1,4 +1,4 @@
 'socket.io':
-  versions: ">=3"
+  versions: ">=2"
   commands:
     - yarn test

--- a/packages/instrumentation-socket.io/README.md
+++ b/packages/instrumentation-socket.io/README.md
@@ -34,7 +34,9 @@ socket.io instrumentation has few options available to choose from. You can set 
 | Options        | Type                                   | Description                                                                                     |
 | -------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | `emitHook` | `SocketIoHookFunction` | hook for adding custom attributes before socket.io emits the event |
+| `emitIgnoreEventList` | `string[]` | names of emitted events to ignore |
 | `onHook` | `SocketIoHookFunction` | hook for adding custom attributes before the event listener (callback) is invoked |
+| `onIgnoreEventList` | `string[]` | names of listened events to ignore |
 | `traceReserved` | `boolean` | set to true if you want to trace socket.io reserved events (see https://socket.io/docs/v4/emit-cheatsheet/#Reserved-events) |
 | `filterHttpTransport`| `HttpTransportInstrumentationConfig` | set if you want to filter out the HTTP traces when using HTTP polling as the transport (see below)
 

--- a/packages/instrumentation-socket.io/README.md
+++ b/packages/instrumentation-socket.io/README.md
@@ -34,9 +34,9 @@ socket.io instrumentation has few options available to choose from. You can set 
 | Options        | Type                                   | Description                                                                                     |
 | -------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | `emitHook` | `SocketIoHookFunction` | hook for adding custom attributes before socket.io emits the event |
-| `emitIgnoreEventList` | `string[]` | names of emitted events to ignore |
+| `emitIgnoreEventList` | `string[]` | names of emitted events to ignore tracing for |
 | `onHook` | `SocketIoHookFunction` | hook for adding custom attributes before the event listener (callback) is invoked |
-| `onIgnoreEventList` | `string[]` | names of listened events to ignore |
+| `onIgnoreEventList` | `string[]` | names of listened events to ignore tracing for |
 | `traceReserved` | `boolean` | set to true if you want to trace socket.io reserved events (see https://socket.io/docs/v4/emit-cheatsheet/#Reserved-events) |
 | `filterHttpTransport`| `HttpTransportInstrumentationConfig` | set if you want to filter out the HTTP traces when using HTTP polling as the transport (see below)
 

--- a/packages/instrumentation-socket.io/package.json
+++ b/packages/instrumentation-socket.io/package.json
@@ -57,8 +57,8 @@
         "mocha": "^8.4.0",
         "opentelemetry-instrumentation-mocha": "0.0.1-rc.4",
         "opentelemetry-instrumentation-testing-utils": "^0.23.0",
-        "socket.io": "^4.1.2",
-        "socket.io-client": "^4.1.1",
+        "socket.io": "^4.1.3",
+        "socket.io-client": "^4.1.3",
         "test-all-versions": "^5.0.1",
         "typescript": "4.3.4"
     },

--- a/packages/instrumentation-socket.io/src/socket.io.ts
+++ b/packages/instrumentation-socket.io/src/socket.io.ts
@@ -22,6 +22,12 @@ export class SocketIoInstrumentation extends InstrumentationBase<Io> {
     protected override _config!: SocketIoInstrumentationConfig;
 
     constructor(config: SocketIoInstrumentationConfig = {}) {
+        if (!Array.isArray(config.emitIgnoreEventList)) {
+            config.emitIgnoreEventList = [];
+        }
+        if (!Array.isArray(config.onIgnoreEventList)) {
+            config.onIgnoreEventList = [];
+        }
         super('opentelemetry-instrumentation-socket.io', VERSION, Object.assign({}, config));
         if (config.filterHttpTransport) {
             const httpInstrumentationConfig =
@@ -137,6 +143,9 @@ export class SocketIoInstrumentation extends InstrumentationBase<Io> {
                 if (!self._config.traceReserved && reservedEvents.includes(ev)) {
                     return original.apply(this, arguments);
                 }
+                if (Array.isArray(self._config.onIgnoreEventList) && self._config.onIgnoreEventList.includes(ev)) {
+                    return original.apply(this, arguments);
+                }
                 const wrappedListener = function (...args: any[]) {
                     const eventName = ev;
                     const defaultNamespace = '/';
@@ -204,6 +213,9 @@ export class SocketIoInstrumentation extends InstrumentationBase<Io> {
         return (original: Function) => {
             return function (ev: any, ...args: any[]) {
                 if (!self._config.traceReserved && reservedEvents.includes(ev)) {
+                    return original.apply(this, arguments);
+                }
+                if (Array.isArray(self._config.emitIgnoreEventList) && self._config.emitIgnoreEventList.includes(ev)) {
                     return original.apply(this, arguments);
                 }
                 const messagingSystem = 'socket.io';

--- a/packages/instrumentation-socket.io/src/types.ts
+++ b/packages/instrumentation-socket.io/src/types.ts
@@ -27,8 +27,12 @@ export interface HttpTransportInstrumentationConfig {
 export interface SocketIoInstrumentationConfig extends InstrumentationConfig {
     /** Hook for adding custom attributes before socket.io emits the event */
     emitHook?: SocketIoHookFunction;
+    /** list of events to ignore tracing on for socket.io emits */
+    emitIgnoreEventList?: string[];
     /** Hook for adding custom attributes before the event listener (callback) is invoked */
     onHook?: SocketIoHookFunction;
+    /** list of events to ignore tracing on for socket.io listeners */
+    onIgnoreEventList?: string[];
     /** Set to `true` if you want to trace socket.io reserved events (see https://socket.io/docs/v4/emit-cheatsheet/#Reserved-events) */
     traceReserved?: boolean;
     /** Set to `TransportInstrumentationConfig` if you want to filter out socket.io HTTP transport  */

--- a/packages/instrumentation-socket.io/test/config.spec.ts
+++ b/packages/instrumentation-socket.io/test/config.spec.ts
@@ -1,4 +1,4 @@
-import { defaultSocketIoPath, SocketIoInstrumentation } from '../src';
+import { defaultSocketIoPath, SocketIoInstrumentation, SocketIoInstrumentationConfig } from '../src';
 import { HttpInstrumentation, HttpInstrumentationConfig } from '@opentelemetry/instrumentation-http';
 import expect from 'expect';
 
@@ -29,5 +29,18 @@ describe('SocketIoInstrumentationConfig', () => {
             const httpInstrumentationConfig = httpInstrumentation.getConfig() as HttpInstrumentationConfig;
             expect(httpInstrumentationConfig.ignoreIncomingPaths).toContain(path);
         });
+    });
+
+    it('forces *IgnoreEventList to be an Array', () => {
+        const socketIoInstrumentation = new SocketIoInstrumentation({
+            onIgnoreEventList: {} as any,
+            emitIgnoreEventList: 1 as any,
+        });
+
+        const { onIgnoreEventList, emitIgnoreEventList } =
+            socketIoInstrumentation.getConfig() as SocketIoInstrumentationConfig;
+
+        expect(Array.isArray(onIgnoreEventList)).toEqual(true);
+        expect(Array.isArray(emitIgnoreEventList)).toEqual(true);
     });
 });

--- a/packages/instrumentation-socket.io/test/socket.io.spec.ts
+++ b/packages/instrumentation-socket.io/test/socket.io.spec.ts
@@ -11,6 +11,7 @@ import { createServer, createServerInstance, io, getSocketIoSpans, expectSpan, i
 describe('SocketIoInstrumentation', () => {
     beforeEach(() => {
         instrumentation.enable();
+        instrumentation.setConfig({});
     });
 
     afterEach(() => {

--- a/packages/instrumentation-socket.io/test/socket.io.spec.ts
+++ b/packages/instrumentation-socket.io/test/socket.io.spec.ts
@@ -308,14 +308,16 @@ describe('SocketIoInstrumentation', () => {
                     socket.emit('test');
                     client.close();
                     sio.close();
-                    expectSpan(`/[${socket.id}] send`, (span) => {
-                        try {
-                            expect(span.kind).toEqual(SpanKind.PRODUCER);
-                            expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('socket.io');
-                            done();
-                        } catch (e) {
-                            done(e);
-                        }
+                    setTimeout(() => {
+                        expectSpan(`/[${socket.id}] send`, (span) => {
+                            try {
+                                expect(span.kind).toEqual(SpanKind.PRODUCER);
+                                expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('socket.io');
+                                done();
+                            } catch (e) {
+                                done(e);
+                            }
+                        }, 2);
                     });
                 });
             });

--- a/packages/instrumentation-socket.io/test/socket.io.spec.ts
+++ b/packages/instrumentation-socket.io/test/socket.io.spec.ts
@@ -304,7 +304,10 @@ describe('SocketIoInstrumentation', () => {
             };
             instrumentation.setConfig(config);
             createServer((sio, port) => {
-                const client = io(`http://localhost:${port}`);
+                const client = io(`http://localhost:${port}`, {
+                    // websockets transport disconnects without the delay of the polling interval
+                    transports: ['websocket'],
+                });
                 sio.on('connection', (socket: Socket) => {
                     socket.emit('test');
                     client.close();

--- a/packages/instrumentation-socket.io/test/socket.io.spec.ts
+++ b/packages/instrumentation-socket.io/test/socket.io.spec.ts
@@ -310,15 +310,19 @@ describe('SocketIoInstrumentation', () => {
                     client.close();
                     sio.close();
                     setTimeout(() => {
-                        expectSpan(`/[${socket.id}] send`, (span) => {
-                            try {
-                                expect(span.kind).toEqual(SpanKind.PRODUCER);
-                                expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('socket.io');
-                                done();
-                            } catch (e) {
-                                done(e);
-                            }
-                        }, 2);
+                        expectSpan(
+                            `/[${socket.id}] send`,
+                            (span) => {
+                                try {
+                                    expect(span.kind).toEqual(SpanKind.PRODUCER);
+                                    expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('socket.io');
+                                    done();
+                                } catch (e) {
+                                    done(e);
+                                }
+                            },
+                            2
+                        );
                     });
                 });
             });

--- a/packages/instrumentation-socket.io/test/socket.io.spec.ts
+++ b/packages/instrumentation-socket.io/test/socket.io.spec.ts
@@ -234,7 +234,6 @@ describe('SocketIoInstrumentation', () => {
                             } catch (e) {
                                 done(e);
                             }
-
                         });
                     });
                 });

--- a/packages/instrumentation-socket.io/test/utils.ts
+++ b/packages/instrumentation-socket.io/test/utils.ts
@@ -32,7 +32,7 @@ export const createServer = (callback: (server: Server, port: number) => void) =
 
 export const createServerInstance = (server?: http.Server) => {
     if (isV2) {
-        return (socketIo as any)(server);
+        return (socketIo as any)(server, { serveClient: false });
     }
     return new Server(server);
 };

--- a/packages/instrumentation-socket.io/test/utils.ts
+++ b/packages/instrumentation-socket.io/test/utils.ts
@@ -16,6 +16,8 @@ const version = require('../node_modules/socket.io/package.json').version;
 
 assert.equal(typeof version, 'string');
 
+export const isV2 = version && /^2\./.test(version);
+
 export const createServer = (callback: (server: Server, port: number) => void) => {
     const server = http.createServer();
     const sio = createServerInstance(server);
@@ -26,7 +28,7 @@ export const createServer = (callback: (server: Server, port: number) => void) =
 };
 
 export const createServerInstance = (server?: http.Server) => {
-    if (version && /^2\./.test(version)) {
+    if (isV2) {
         return (socketIo as any)(server);
     }
     return new Server(server);


### PR DESCRIPTION
This is currently WIP. And includes prep work from another PR(https://github.com/aspecto-io/opentelemetry-ext-js/pull/151). Test pass but there is

1. a race condition - Socket."emit is instrumented" test passes only because we don't wait for all the spans. There are async timers that are not cleaned up and process never terminates.
2. a problem with some internal state somewhere in Namespace tests - they pass beautifully if all the tests are ran together, but if only Namespace."on is instrumented" is ran, it fails with wrong number of spans created.

Should be easy enough fixes. The general theme should stay as it is right now so a preliminary review would also be nice! :wink:

EDIT

Solved the abovementioned issues and polished some last things. To reference points above:

1. Changed the test to use `websockets` transport, because whatever I did, I couldn't get the socket to terminate with `polling` before the polling interval ended.
2. Tests were fine here, but since the instrumentation instance was not recreated for every test, Namespace tests relied on the previous tests to be run. The internal state turned up to be the configuration for the instrumentation.
