### PR TITLE
fix: Use AWS SDK Instrument spec for common attributes

### DIFF
--- a/packages/instrumentation-aws-sdk/.tav.yml
+++ b/packages/instrumentation-aws-sdk/.tav.yml
@@ -6,11 +6,11 @@
     - yarn test
 
 '@aws-sdk/client-s3':
-  versions: ">=3.0.0"
+  versions: ">=3.0.1"
   commands:
     - yarn test
 
 '@aws-sdk/client-sqs':
-  versions: ">=3.0.0"
+  versions: ">=3.0.1"
   commands:
     - yarn test

--- a/packages/instrumentation-aws-sdk/.tav.yml
+++ b/packages/instrumentation-aws-sdk/.tav.yml
@@ -6,11 +6,11 @@
     - yarn test
 
 '@aws-sdk/client-s3':
-  versions: ">=3.0.1"
+  versions: ">=3.1.0"
   commands:
     - yarn test
 
 '@aws-sdk/client-sqs':
-  versions: ">=3.0.1"
+  versions: ">=3.1.0"
   commands:
     - yarn test

--- a/packages/instrumentation-aws-sdk/README.md
+++ b/packages/instrumentation-aws-sdk/README.md
@@ -53,8 +53,8 @@ Both V2 and V3 instrumentations are collecting the following attributes:
 | Attribute Name | Type | Description | Example |
 | -------------- | ---- | ----------- | ------- |
 | `rpc.system` | string | Always equals "aws-api" | 
-| `rpc.method` | string | The name of the operation corresponding to the request | `PutObject` |
-| `rpc.service` | string | The name of the service to which a request is made, as returned by the AWS SDK | `S3`, `DynamoDB`, `Route 53` |
+| `rpc.method` | string | he name of the operation corresponding to the request, as returned by the AWS SDK. If the SDK does not provide a way to retrieve a name, the name of the command SHOULD be used, removing the suffix `Command` if present, resulting in a PascalCase name with no spaces. | `PutObject` |
+| `rpc.service` | string | The name of the service to which a request is made, as returned by the AWS SDK. If the SDK does not provide a away to retrieve a name, the name of the SDK's client interface for a service SHOULD be used, removing the suffix `Client` if present, resulting in a PascalCase name with no spaces. | `S3`, `DynamoDB`, `Route53` |
 | `aws.region` | string | Region name for the request | "eu-west-1" |
 
 ### V2 attributes

--- a/packages/instrumentation-aws-sdk/README.md
+++ b/packages/instrumentation-aws-sdk/README.md
@@ -54,7 +54,7 @@ Both V2 and V3 instrumentations are collecting the following attributes:
 | -------------- | ---- | ----------- | ------- |
 | `rpc.system` | string | Always equals "aws-api" | 
 | `rpc.method` | string | The name of the operation corresponding to the request | `PutObject` |
-| `rpc.service` | string | The name of the service to which a request is made, as returned by the AWS SDK | `S3`, `DynamoDB` |
+| `rpc.service` | string | The name of the service to which a request is made, as returned by the AWS SDK | `S3`, `DynamoDB`, `Route 53` |
 | `aws.region` | string | Region name for the request | "eu-west-1" |
 
 ### V2 attributes

--- a/packages/instrumentation-aws-sdk/README.md
+++ b/packages/instrumentation-aws-sdk/README.md
@@ -53,8 +53,8 @@ Both V2 and V3 instrumentations are collecting the following attributes:
 | Attribute Name | Type | Description | Example |
 | -------------- | ---- | ----------- | ------- |
 | `rpc.system` | string | Always equals "aws-api" | 
-| `rpc.method` | string | The name of the operation corresponding to the request, normalized to camelCase | `putObject` |
-| `rpc.service` | string | The name of the service to which a request is made, as returned by the AWS SDK, normalized to lower case | `s3` | 
+| `rpc.method` | string | The name of the operation corresponding to the request | `PutObject` |
+| `rpc.service` | string | The name of the service to which a request is made, as returned by the AWS SDK | `S3`, `DynamoDB` |
 | `aws.region` | string | Region name for the request | "eu-west-1" |
 
 ### V2 attributes

--- a/packages/instrumentation-aws-sdk/src/aws-sdk.ts
+++ b/packages/instrumentation-aws-sdk/src/aws-sdk.ts
@@ -170,7 +170,7 @@ export class AwsInstrumentation extends InstrumentationBase<typeof AWS> {
         const operation = (request as any).operation;
         const service = (request as any).service;
         const serviceIdentifier = service?.serviceIdentifier;
-        const name = metadata.spanName ?? this._getSpanName(serviceIdentifier, operation);
+        const name = metadata.spanName ?? `${normalizedRequest.serviceName}.${normalizedRequest.commandName}`;
 
         const newSpan = this.tracer.startSpan(name, {
             kind: metadata.spanKind ?? SpanKind.CLIENT,
@@ -443,10 +443,6 @@ export class AwsInstrumentation extends InstrumentationBase<typeof AWS> {
             return requestMetadata.isIncoming ? bindPromise(origPromise, activeContextWithSpan) : origPromise;
         };
     }
-
-    private _getSpanName = (serviceIdentifier: string, operation: string) => {
-        return `aws.${serviceIdentifier ?? 'request'}.${operation}`;
-    };
 
     private _callOriginalFunction<T>(originalFunction: (...args: any[]) => T): T {
         if (this._config?.suppressInternalInstrumentation) {

--- a/packages/instrumentation-aws-sdk/src/aws-sdk.ts
+++ b/packages/instrumentation-aws-sdk/src/aws-sdk.ts
@@ -57,7 +57,7 @@ export class AwsInstrumentation extends InstrumentationBase<typeof AWS> {
     protected init(): InstrumentationModuleDefinition<typeof AWS>[] {
         const v3MiddlewareStackFile = new InstrumentationNodeModuleFile(
             `@aws-sdk/middleware-stack/dist/cjs/MiddlewareStack.js`,
-            ['^3.0.0'],
+            ['^3.1.0'],
             this.patchV3ConstructStack.bind(this),
             this.unpatchV3ConstructStack.bind(this)
         );
@@ -67,7 +67,7 @@ export class AwsInstrumentation extends InstrumentationBase<typeof AWS> {
         // so we are patching the MiddlewareStack.js file directly to get around it.
         const v3MiddlewareStack = new InstrumentationNodeModuleDefinition<typeof AWS>(
             '@aws-sdk/middleware-stack',
-            ['^3.0.0'],
+            ['^3.1.0'],
             undefined,
             undefined,
             [v3MiddlewareStackFile]
@@ -75,7 +75,7 @@ export class AwsInstrumentation extends InstrumentationBase<typeof AWS> {
 
         const v3SmithyClient = new InstrumentationNodeModuleDefinition<typeof AWS>(
             '@aws-sdk/smithy-client',
-            ['^3.0.0'],
+            ['^3.1.0'],
             this.patchV3SmithyClient.bind(this),
             this.unpatchV3SmithyClient.bind(this)
         );

--- a/packages/instrumentation-aws-sdk/src/services/ServicesExtensions.ts
+++ b/packages/instrumentation-aws-sdk/src/services/ServicesExtensions.ts
@@ -8,8 +8,8 @@ export class ServicesExtensions implements ServiceExtension {
     services: Map<string, ServiceExtension> = new Map();
 
     constructor() {
-        this.services.set('sqs', new SqsServiceExtension());
-        this.services.set('dynamodb', new DynamodbServiceExtension());
+        this.services.set('SQS', new SqsServiceExtension());
+        this.services.set('DynamoDB', new DynamodbServiceExtension());
     }
 
     requestPreSpanHook(request: NormalizedRequest): RequestMetadata {

--- a/packages/instrumentation-aws-sdk/src/services/sqs.ts
+++ b/packages/instrumentation-aws-sdk/src/services/sqs.ts
@@ -60,7 +60,7 @@ export class SqsServiceExtension implements ServiceExtension {
         let isIncoming = false;
 
         switch (request.commandName) {
-            case 'receiveMessage':
+            case 'ReceiveMessage':
                 {
                     isIncoming = true;
                     spanKind = SpanKind.CONSUMER;
@@ -73,8 +73,8 @@ export class SqsServiceExtension implements ServiceExtension {
                 }
                 break;
 
-            case 'sendMessage':
-            case 'sendMessageBatch':
+            case 'SendMessage':
+            case 'SendMessageBatch':
                 spanKind = SpanKind.PRODUCER;
                 spanName = `${queueName} send`;
                 break;
@@ -90,7 +90,7 @@ export class SqsServiceExtension implements ServiceExtension {
 
     requestPostSpanHook = (request: NormalizedRequest) => {
         switch (request.commandName) {
-            case 'sendMessage':
+            case 'SendMessage':
                 {
                     const origMessageAttributes = request.commandInput['MessageAttributes'] ?? {};
                     if (origMessageAttributes) {
@@ -100,7 +100,7 @@ export class SqsServiceExtension implements ServiceExtension {
                 }
                 break;
 
-            case 'sendMessageBatch':
+            case 'SendMessageBatch':
                 {
                     request.commandInput?.Entries?.forEach((messageParams: SQS.SendMessageBatchRequestEntry) => {
                         messageParams.MessageAttributes = this.InjectPropagationContext(

--- a/packages/instrumentation-aws-sdk/src/utils.ts
+++ b/packages/instrumentation-aws-sdk/src/utils.ts
@@ -15,7 +15,7 @@ export const removeSuffixFromStringIfExists = (str: string, suffixToRemove: stri
 export const normalizeV2Request = (awsV2Request: Request<any, any>): NormalizedRequest => {
     const service = (awsV2Request as any)?.service;
     return {
-        serviceName: service?.api?.serviceId,
+        serviceName: service?.api?.serviceId.replace(/\s+/g, ''),
         commandName: toPascalCase((awsV2Request as any)?.operation),
         commandInput: (awsV2Request as any).params,
         region: service?.config?.region,
@@ -29,7 +29,7 @@ export const normalizeV3Request = (
     region: string
 ): NormalizedRequest => {
     return {
-        serviceName,
+        serviceName: serviceName.replace(/\s+/g, ''),
         commandName: removeSuffixFromStringIfExists(commandNameWithSuffix, 'Command'),
         commandInput,
         region,

--- a/packages/instrumentation-aws-sdk/src/utils.ts
+++ b/packages/instrumentation-aws-sdk/src/utils.ts
@@ -14,10 +14,9 @@ export const removeSuffixFromStringIfExists = (str: string, suffixToRemove: stri
 
 export const normalizeV2Request = (awsV2Request: Request<any, any>): NormalizedRequest => {
     const service = (awsV2Request as any)?.service;
-    const operation = (awsV2Request as any).operation;
     return {
         serviceName: service?.api?.serviceId,
-        commandName: toPascalCase(operation),
+        commandName: toPascalCase((awsV2Request as any)?.operation),
         commandInput: (awsV2Request as any).params,
         region: service?.config?.region,
     };

--- a/packages/instrumentation-aws-sdk/src/utils.ts
+++ b/packages/instrumentation-aws-sdk/src/utils.ts
@@ -4,8 +4,8 @@ import { Context, SpanAttributes, context } from '@opentelemetry/api';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { AttributeNames } from './enums';
 
-const toCamelCase = (str: string): string =>
-    typeof str === 'string' ? str.charAt(0).toLowerCase() + str.slice(1) : str;
+const toPascalCase = (str: string): string =>
+    typeof str === 'string' ? str.charAt(0).toUpperCase() + str.slice(1) : str;
 
 export const removeSuffixFromStringIfExists = (str: string, suffixToRemove: string): string => {
     const suffixLength = suffixToRemove.length;
@@ -14,9 +14,10 @@ export const removeSuffixFromStringIfExists = (str: string, suffixToRemove: stri
 
 export const normalizeV2Request = (awsV2Request: Request<any, any>): NormalizedRequest => {
     const service = (awsV2Request as any)?.service;
+    const operation = (awsV2Request as any).operation;
     return {
-        serviceName: service?.serviceIdentifier?.toLowerCase(),
-        commandName: toCamelCase((awsV2Request as any).operation),
+        serviceName: service?.api?.serviceId,
+        commandName: toPascalCase(operation),
         commandInput: (awsV2Request as any).params,
         region: service?.config?.region,
     };
@@ -28,10 +29,9 @@ export const normalizeV3Request = (
     commandInput: Record<string, any>,
     region: string
 ): NormalizedRequest => {
-    const commandName = toCamelCase(removeSuffixFromStringIfExists(commandNameWithSuffix, 'Command'));
     return {
-        serviceName: serviceName?.toLowerCase(),
-        commandName,
+        serviceName,
+        commandName: removeSuffixFromStringIfExists(commandNameWithSuffix, 'Command'),
         commandInput,
         region,
     };

--- a/packages/instrumentation-aws-sdk/test/aws-sdk-v2.spec.ts
+++ b/packages/instrumentation-aws-sdk/test/aws-sdk-v2.spec.ts
@@ -86,7 +86,7 @@ describe('instrumentation-aws-sdk-v2', () => {
                 expect(spanCreateBucket.attributes[AttributeNames.AWS_REQUEST_ID]).toBe(responseMockSuccess.requestId);
                 expect(spanCreateBucket.attributes[AttributeNames.AWS_REGION]).toBe('us-east-1');
 
-                expect(spanCreateBucket.name).toBe('aws.s3.createBucket');
+                expect(spanCreateBucket.name).toBe('S3.CreateBucket');
 
                 expect(spanPutObject.attributes[AttributeNames.AWS_OPERATION]).toBe('putObject');
                 expect(spanPutObject.attributes[AttributeNames.AWS_SIGNATURE_VERSION]).toBe('s3');
@@ -95,7 +95,7 @@ describe('instrumentation-aws-sdk-v2', () => {
                 expect(spanPutObject.attributes[AttributeNames.AWS_SERVICE_NAME]).toBe('Amazon S3');
                 expect(spanPutObject.attributes[AttributeNames.AWS_REQUEST_ID]).toBe(responseMockSuccess.requestId);
                 expect(spanPutObject.attributes[AttributeNames.AWS_REGION]).toBe('us-east-1');
-                expect(spanPutObject.name).toBe('aws.s3.putObject');
+                expect(spanPutObject.name).toBe('S3.PutObject');
             });
 
             it('adds proper number of spans with correct attributes if both, promise and callback were used', async () => {

--- a/packages/instrumentation-aws-sdk/test/aws-sdk-v3.spec.ts
+++ b/packages/instrumentation-aws-sdk/test/aws-sdk-v3.spec.ts
@@ -47,10 +47,10 @@ describe('instrumentation-aws-sdk-v3', () => {
             expect(getTestSpans().length).toBe(1);
             const [span] = getTestSpans();
             expect(span.attributes[SemanticAttributes.RPC_SYSTEM]).toEqual('aws-api');
-            expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual('putObject');
-            expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('s3');
+            expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual('PutObject');
+            expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('S3');
             expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
-            expect(span.name).toEqual('s3.putObject');
+            expect(span.name).toEqual('S3.PutObject');
         });
 
         it('callback interface', (done) => {
@@ -63,10 +63,10 @@ describe('instrumentation-aws-sdk-v3', () => {
                 expect(getTestSpans().length).toBe(1);
                 const [span] = getTestSpans();
                 expect(span.attributes[SemanticAttributes.RPC_SYSTEM]).toEqual('aws-api');
-                expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual('putObject');
-                expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('s3');
+                expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual('PutObject');
+                expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('S3');
                 expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
-                expect(span.name).toEqual('s3.putObject');
+                expect(span.name).toEqual('S3.PutObject');
                 done();
             });
         });
@@ -82,10 +82,10 @@ describe('instrumentation-aws-sdk-v3', () => {
             expect(getTestSpans().length).toBe(1);
             const [span] = getTestSpans();
             expect(span.attributes[SemanticAttributes.RPC_SYSTEM]).toEqual('aws-api');
-            expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual('putObject');
-            expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('s3');
+            expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual('PutObject');
+            expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('S3');
             expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
-            expect(span.name).toEqual('s3.putObject');
+            expect(span.name).toEqual('S3.PutObject');
         });
 
         it('aws error', async () => {
@@ -108,11 +108,11 @@ describe('instrumentation-aws-sdk-v3', () => {
                 expect(span.events[0].name).toEqual('exception');
 
                 expect(span.attributes[SemanticAttributes.RPC_SYSTEM]).toEqual('aws-api');
-                expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual('putObject');
-                expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('s3');
+                expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual('PutObject');
+                expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('S3');
                 expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
                 expect(span.attributes[AttributeNames.AWS_REQUEST_ID]).toEqual('MS95GTS7KXQ34X2S');
-                expect(span.name).toEqual('s3.putObject');
+                expect(span.name).toEqual('S3.PutObject');
             }
         });
     });
@@ -198,7 +198,7 @@ describe('instrumentation-aws-sdk-v3', () => {
     });
 
     describe('custom service behavior', () => {
-        describe('sqs', () => {
+        describe('SQS', () => {
             const sqsClient = new SQS({ region });
 
             it('sqs send add messaging attributes', async () => {
@@ -216,8 +216,8 @@ describe('instrumentation-aws-sdk-v3', () => {
 
                 // make sure we have the general aws attributes:
                 expect(span.attributes[SemanticAttributes.RPC_SYSTEM]).toEqual('aws-api');
-                expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual('sendMessage');
-                expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('sqs');
+                expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual('SendMessage');
+                expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('SQS');
                 expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
 
                 // custom messaging attributes
@@ -244,8 +244,8 @@ describe('instrumentation-aws-sdk-v3', () => {
 
                     // make sure we have the general aws attributes:
                     expect(span.attributes[SemanticAttributes.RPC_SYSTEM]).toEqual('aws-api');
-                    expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual('receiveMessage');
-                    expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('sqs');
+                    expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual('ReceiveMessage');
+                    expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('SQS');
                     expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
 
                     const receiveCallbackSpan = trace.getSpan(context.active());

--- a/packages/instrumentation-aws-sdk/test/dynamodb.spec.ts
+++ b/packages/instrumentation-aws-sdk/test/dynamodb.spec.ts
@@ -15,7 +15,7 @@ const responseMockSuccess = {
     error: null,
 };
 
-describe('dynamodb', () => {
+describe('DynamoDB', () => {
     before(() => {
         AWS.config.credentials = {
             accessKeyId: 'test key id',
@@ -62,7 +62,7 @@ describe('dynamodb', () => {
                 const attrs = spans[0].attributes;
                 expect(attrs[SemanticAttributes.DB_SYSTEM]).toStrictEqual('dynamodb');
                 expect(attrs[SemanticAttributes.DB_NAME]).toStrictEqual('test-table');
-                expect(attrs[SemanticAttributes.DB_OPERATION]).toStrictEqual('query');
+                expect(attrs[SemanticAttributes.DB_OPERATION]).toStrictEqual('Query');
                 expect(JSON.parse(attrs[SemanticAttributes.DB_STATEMENT] as string)).toEqual(params);
                 expect(err).toBeFalsy();
                 done();

--- a/packages/instrumentation-aws-sdk/test/sqs.spec.ts
+++ b/packages/instrumentation-aws-sdk/test/sqs.spec.ts
@@ -49,7 +49,7 @@ describe('SQS', () => {
             const childSpan = trace
                 .getTracerProvider()
                 .getTracer('default')
-                .startSpan('child span of sqs.receiveMessage');
+                .startSpan('child span of SQS.ReceiveMessage');
             childSpan.end();
         };
 

--- a/packages/instrumentation-aws-sdk/test/sqs.spec.ts
+++ b/packages/instrumentation-aws-sdk/test/sqs.spec.ts
@@ -18,7 +18,7 @@ const responseMockSuccess = {
     error: null,
 };
 
-describe('sqs', () => {
+describe('SQS', () => {
     before(() => {
         AWS.config.credentials = {
             accessKeyId: 'test key id',


### PR DESCRIPTION
# Description

Update the `opentelmetry-instrumentation-aws-sdk` package to follow the [common attributes in the specification for instrumentation of the AWS SDK](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/instrumentation/aws-sdk.md#common-attributes), specifically, this PR only address the issues with the "common attributes".

# Updates

* `rpc.service` uses the unmodified `service.serviceIdentifier` instead of converting it to lower case
* `rpc.method` uses the unmodified `awsV2Request.operation` instead of converting it to CamelCase

Related to #160 