### PR TITLE
feat: Add spec defined attributes for DynamoDB `BatchGetItem`

### DIFF
--- a/packages/instrumentation-aws-sdk/package.json
+++ b/packages/instrumentation-aws-sdk/package.json
@@ -45,6 +45,7 @@
         "opentelemetry-propagation-utils": "^0.24.0"
     },
     "devDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.24.0",
         "@aws-sdk/client-s3": "3.13.1",
         "@aws-sdk/client-sqs": "3.13.1",
         "@aws-sdk/types": "3.13.1",

--- a/packages/instrumentation-aws-sdk/src/services/dynamodb.ts
+++ b/packages/instrumentation-aws-sdk/src/services/dynamodb.ts
@@ -2,7 +2,6 @@ import { Span, SpanKind, Tracer } from '@opentelemetry/api';
 import { RequestMetadata, ServiceExtension } from './ServiceExtension';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { AwsSdkInstrumentationConfig, NormalizedRequest, NormalizedResponse } from '../types';
-import type { Request } from 'aws-sdk';
 
 export class DynamodbServiceExtension implements ServiceExtension {
     requestPreSpanHook(normalizedRequest: NormalizedRequest): RequestMetadata {
@@ -36,10 +35,12 @@ export class DynamodbServiceExtension implements ServiceExtension {
         const operation = response.request.commandName;
 
         if (operation === 'BatchGetItem') {
-            span.setAttribute(
-                SemanticAttributes.AWS_DYNAMODB_CONSUMED_CAPACITY,
-                response.data.ConsumedCapacity.map((x: Object) => JSON.stringify(x))
-            );
+            if ('ConsumedCapacity' in response.data) {
+                span.setAttribute(
+                    SemanticAttributes.AWS_DYNAMODB_CONSUMED_CAPACITY,
+                    response.data.ConsumedCapacity.map((x: { [DictionaryKey: string]: any }) => JSON.stringify(x))
+                );
+            }
         }
     }
 }

--- a/packages/instrumentation-aws-sdk/src/services/dynamodb.ts
+++ b/packages/instrumentation-aws-sdk/src/services/dynamodb.ts
@@ -1,21 +1,28 @@
-import { SpanKind } from '@opentelemetry/api';
+import { Span, SpanKind, Tracer } from '@opentelemetry/api';
 import { RequestMetadata, ServiceExtension } from './ServiceExtension';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
-import { NormalizedRequest } from '../types';
+import { AwsSdkInstrumentationConfig, NormalizedRequest, NormalizedResponse } from '../types';
+import type { Request } from 'aws-sdk';
 
 export class DynamodbServiceExtension implements ServiceExtension {
-    requestPreSpanHook(request: NormalizedRequest): RequestMetadata {
+    requestPreSpanHook(normalizedRequest: NormalizedRequest): RequestMetadata {
         let spanKind: SpanKind = SpanKind.CLIENT;
         let spanName: string;
         let isIncoming = false;
-        const operation = request.commandName;
+        const operation = normalizedRequest.commandName;
 
         const spanAttributes = {
             [SemanticAttributes.DB_SYSTEM]: 'dynamodb',
-            [SemanticAttributes.DB_NAME]: request.commandInput?.TableName,
+            [SemanticAttributes.DB_NAME]: normalizedRequest.commandInput?.TableName,
             [SemanticAttributes.DB_OPERATION]: operation,
-            [SemanticAttributes.DB_STATEMENT]: JSON.stringify(request.commandInput),
+            [SemanticAttributes.DB_STATEMENT]: JSON.stringify(normalizedRequest.commandInput),
         };
+
+        if (operation == 'BatchGetItem') {
+            spanAttributes[SemanticAttributes.AWS_DYNAMODB_TABLE_NAMES] = Object.keys(
+                normalizedRequest.commandInput.RequestItems
+            );
+        }
 
         return {
             isIncoming,
@@ -23,5 +30,16 @@ export class DynamodbServiceExtension implements ServiceExtension {
             spanKind,
             spanName,
         };
+    }
+
+    responseHook(response: NormalizedResponse, span: Span, tracer: Tracer, config: AwsSdkInstrumentationConfig) {
+        const operation = response.request.commandName;
+
+        if (operation === 'BatchGetItem') {
+            span.setAttribute(
+                SemanticAttributes.AWS_DYNAMODB_CONSUMED_CAPACITY,
+                response.data.ConsumedCapacity.map((x: Object) => JSON.stringify(x))
+            );
+        }
     }
 }

--- a/packages/instrumentation-aws-sdk/test/dynamodb.spec.ts
+++ b/packages/instrumentation-aws-sdk/test/dynamodb.spec.ts
@@ -4,6 +4,10 @@ import { mockAwsSend } from './testing-utils';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import expect from 'expect';
 import { getTestSpans } from 'opentelemetry-instrumentation-testing-utils';
+import type { ConsumedCapacity as ConsumedCapacityV2 } from 'aws-sdk/clients/dynamodb';
+import type { ConsumedCapacity as ConsumedCapacityV3 } from '@aws-sdk/client-dynamodb';
+
+type ConsumedCapacity = ConsumedCapacityV2 | ConsumedCapacityV3;
 
 const instrumentation = new AwsInstrumentation();
 instrumentation.enable();
@@ -67,23 +71,59 @@ describe('DynamoDB', () => {
         });
     });
 
-    describe('BatchGetIem', () => {
-        beforeEach(() => {
+    describe('BatchGetItem', () => {
+        const consumedCapacityResponseMockData: ConsumedCapacity[] = [
+            {
+                TableName: 'test-table',
+                CapacityUnits: 0.5,
+                Table: { CapacityUnits: 0.5 },
+            },
+        ];
+
+        it('should populate BatchGetIem default attributes', (done) => {
             mockAwsSend(responseMockSuccess, {
                 Responses: { 'test-table': [{ key1: { S: 'val1' } }] },
                 UnprocessedKeys: {},
-                ConsumedCapacity: [
-                    {
-                        TableName: 'test-table',
-                        CapacityUnits: 0.5,
-                        Table: { CapacityUnits: 0.5 },
-                    },
-                ],
             } as AWS.DynamoDB.Types.BatchGetItemOutput);
             instrumentation.disable();
             instrumentation.enable();
+
+            const dynamodb = new AWS.DynamoDB.DocumentClient();
+            const dynamodb_params = {
+                RequestItems: {
+                    'test-table': {
+                        Keys: [{ key1: { S: 'val1' } }],
+                        ProjectionExpression: 'id',
+                    },
+                },
+                ReturnConsumedCapacity: 'INDEXES',
+            };
+            dynamodb.batchGet(
+                dynamodb_params,
+                (err: AWSError, data: AWS.DynamoDB.DocumentClient.BatchGetItemOutput) => {
+                    const spans = getTestSpans();
+                    expect(spans.length).toStrictEqual(1);
+                    const attrs = spans[0].attributes;
+                    expect(attrs[SemanticAttributes.DB_SYSTEM]).toStrictEqual('dynamodb');
+                    expect(attrs[SemanticAttributes.DB_OPERATION]).toStrictEqual('BatchGetItem');
+                    expect(attrs[SemanticAttributes.AWS_DYNAMODB_TABLE_NAMES]).toStrictEqual(['test-table']);
+                    expect(attrs[SemanticAttributes.AWS_DYNAMODB_CONSUMED_CAPACITY]).toBeUndefined();
+                    expect(JSON.parse(attrs[SemanticAttributes.DB_STATEMENT] as string)).toEqual(dynamodb_params);
+                    expect(err).toBeFalsy();
+                    done();
+                }
+            );
         });
-        it('should populate specific BatchGetIem attributes', (done) => {
+
+        it('should populate BatchGetIem optional attributes', (done) => {
+            mockAwsSend(responseMockSuccess, {
+                Responses: { 'test-table': [{ key1: { S: 'val1' } }] },
+                UnprocessedKeys: {},
+                ConsumedCapacity: consumedCapacityResponseMockData,
+            } as AWS.DynamoDB.Types.BatchGetItemOutput);
+            instrumentation.disable();
+            instrumentation.enable();
+
             const dynamodb = new AWS.DynamoDB.DocumentClient();
             const dynamodb_params = {
                 RequestItems: {
@@ -104,13 +144,7 @@ describe('DynamoDB', () => {
                     expect(attrs[SemanticAttributes.DB_OPERATION]).toStrictEqual('BatchGetItem');
                     expect(attrs[SemanticAttributes.AWS_DYNAMODB_TABLE_NAMES]).toStrictEqual(['test-table']);
                     expect(attrs[SemanticAttributes.AWS_DYNAMODB_CONSUMED_CAPACITY]).toStrictEqual(
-                        [
-                            {
-                                TableName: 'test-table',
-                                CapacityUnits: 0.5,
-                                Table: { CapacityUnits: 0.5 },
-                            },
-                        ].map((x: Object) => JSON.stringify(x))
+                        consumedCapacityResponseMockData.map((x: ConsumedCapacity) => JSON.stringify(x))
                     );
                     expect(JSON.parse(attrs[SemanticAttributes.DB_STATEMENT] as string)).toEqual(dynamodb_params);
                     expect(err).toBeFalsy();


### PR DESCRIPTION
# Description

PR adds additional attributes for the specific `DynamoDB` `BatchGetItem` command as defined in the specification for instrumentations of the AWS SDKs under the [specific DynamoDB - BatchGetItem](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/instrumentation/aws-sdk.md#dynamodbbatchgetitem) subheading.

# Changes
* Confirmed this works in both V3 and V2 by using the `normalized.commandInput` parameter

Blocked by #162 
