### PR TITLE
feat: Allow extend function from external

### DIFF
--- a/packages/instrumentation-amqplib/src/amqplib.ts
+++ b/packages/instrumentation-amqplib/src/amqplib.ts
@@ -221,7 +221,7 @@ export class AmqplibInstrumentation extends InstrumentationBase<typeof amqp> {
         };
     }
 
-    private getConsumePatch(
+    protected getConsumePatch(
         moduleVersion: string,
         original: (
             queue: string,
@@ -316,7 +316,7 @@ export class AmqplibInstrumentation extends InstrumentationBase<typeof amqp> {
         };
     }
 
-    private getPublishPatch(
+    protected getPublishPatch(
         moduleVersion: string,
         original: (exchange: string, routingKey: string, content: Buffer, options?: amqp.Options.Publish) => boolean
     ) {


### PR DESCRIPTION
Should allow dev to extend the publish and consume method to custom behavior. 

In more steps, should let user set the specific exchange or queue when creating class.