### PR TITLE
fix: Elasticsearch v7.14.0 product check

### DIFF
--- a/packages/instrumentation-elasticsearch/test/elastic.spec.ts
+++ b/packages/instrumentation-elasticsearch/test/elastic.spec.ts
@@ -14,6 +14,9 @@ const client = new Client({ node: esMockUrl });
 describe('elasticsearch instrumentation', () => {
     before(() => {
         instrumentation.enable();
+
+        // Handle Elasticsearch product check
+        esNock.get('/').reply(200, { version: { number: '7.14.0' } }, { 'x-elastic-product': 'Elasticsearch' });
     });
 
     after(() => {


### PR DESCRIPTION
Fix tests for new version `7.14.0`.
Support [new product check](https://github.com/elastic/elasticsearch-js/pull/1487) request.