### PR TITLE
feat: amqp ConfirmChannel instrumentation

### DIFF
--- a/packages/instrumentation-amqplib/src/amqplib.ts
+++ b/packages/instrumentation-amqplib/src/amqplib.ts
@@ -1,4 +1,4 @@
-import { context, diag, propagation, trace, Span, SpanKind, SpanStatusCode, Context } from '@opentelemetry/api';
+import { context, diag, propagation, trace, Span, SpanKind, SpanStatusCode } from '@opentelemetry/api';
 import {
     InstrumentationBase,
     InstrumentationModuleDefinition,

--- a/packages/instrumentation-amqplib/src/amqplib.ts
+++ b/packages/instrumentation-amqplib/src/amqplib.ts
@@ -1,4 +1,4 @@
-import { context, diag, propagation, Span, SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
+import { context, diag, propagation, trace, Span, SpanKind, SpanStatusCode } from '@opentelemetry/api';
 import {
     InstrumentationBase,
     InstrumentationModuleDefinition,
@@ -8,9 +8,9 @@ import {
     safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
 import {
-    MessagingDestinationKindValues,
-    MessagingOperationValues,
     SemanticAttributes,
+    MessagingOperationValues,
+    MessagingDestinationKindValues,
 } from '@opentelemetry/semantic-conventions';
 import type amqp from 'amqplib';
 import { AmqplibInstrumentationConfig, DEFAULT_CONFIG, EndOperation } from './types';
@@ -23,8 +23,6 @@ import {
     normalizeExchange,
 } from './utils';
 import { VERSION } from './version';
-import { Replies } from 'amqplib/properties';
-import { Options } from 'amqplib';
 
 export class AmqplibInstrumentation extends InstrumentationBase<typeof amqp> {
     protected override _config: AmqplibInstrumentationConfig;
@@ -338,7 +336,7 @@ export class AmqplibInstrumentation extends InstrumentationBase<typeof amqp> {
             routingKey: string,
             content: Buffer,
             options?: amqp.Options.Publish,
-            callback?: (err: any, ok: Replies.Empty) => void
+            callback?: (err: any, ok: amqp.Replies.Empty) => void
         ) => boolean
     ) {
         const self = this;
@@ -347,7 +345,7 @@ export class AmqplibInstrumentation extends InstrumentationBase<typeof amqp> {
             routingKey: string,
             content: Buffer,
             options?: amqp.Options.Publish,
-            callback?: (err: any, ok: Replies.Empty) => void
+            callback?: (err: any, ok: amqp.Replies.Empty) => void
         ): boolean {
             const channel = this;
             const { span, modifiedOptions } = self.createPublishSpan(
@@ -371,7 +369,7 @@ export class AmqplibInstrumentation extends InstrumentationBase<typeof amqp> {
                 );
             }
 
-            const patchedOnConfirm = function (err: any, ok: Replies.Empty) {
+            const patchedOnConfirm = function (err: any, ok: amqp.Replies.Empty) {
                 // should we wrap with context and end span after this callback or end span right away?
                 context.with(trace.setSpan(context.active(), span), () => {
                     callback?.call(this, err, ok);
@@ -465,7 +463,7 @@ export class AmqplibInstrumentation extends InstrumentationBase<typeof amqp> {
         routingKey: string,
         channel,
         moduleVersion: string,
-        options?: Options.Publish
+        options?: amqp.Options.Publish
     ) {
         const normalizedExchange = normalizeExchange(exchange);
 

--- a/packages/instrumentation-amqplib/src/amqplib.ts
+++ b/packages/instrumentation-amqplib/src/amqplib.ts
@@ -421,7 +421,6 @@ export class AmqplibInstrumentation extends InstrumentationBase<typeof amqp> {
             const markedContext = markConfirmChannelTracing(context.active());
             const argumentsCopy = [...arguments];
             argumentsCopy[3] = modifiedOptions;
-            //can unmark be here?
             argumentsCopy[4] = context.bind(
                 unmarkConfirmChannelTracing(trace.setSpan(markedContext, span)),
                 patchedOnConfirm

--- a/packages/instrumentation-amqplib/src/types.ts
+++ b/packages/instrumentation-amqplib/src/types.ts
@@ -13,6 +13,10 @@ export interface AmqplibPublishCustomAttributeFunction {
     (span: Span, publishParams: PublishParams): void;
 }
 
+export interface AmqplibConfirmEndCustomAttributeFunction {
+    (span: Span, publishParams: PublishParams, confirmError: any): void;
+}
+
 export interface AmqplibConsumerCustomAttributeFunction {
     (span: Span, msg: amqp.ConsumeMessage | null): void;
 }
@@ -34,8 +38,14 @@ export interface AmqplibConsumerEndCustomAttributeFunction {
 }
 
 export interface AmqplibInstrumentationConfig extends InstrumentationConfig {
-    /** hook for adding custom attributes before publish message is sent */
+    /** hook for adding custom attributes before publish message is sent through normal channel */
     publishHook?: AmqplibPublishCustomAttributeFunction;
+
+    /** hook for adding custom attributes before publish message is sent through confirm channel */
+    publishConfirmHook?: AmqplibPublishCustomAttributeFunction;
+
+    /** hook for adding custom attributes after publish message is confirmed by the broker */
+    publishConfirmEndHook?: AmqplibConfirmEndCustomAttributeFunction;
 
     /** hook for adding custom attributes before consumer message is processed */
     consumeHook?: AmqplibConsumerCustomAttributeFunction;

--- a/packages/instrumentation-amqplib/src/types.ts
+++ b/packages/instrumentation-amqplib/src/types.ts
@@ -10,15 +10,19 @@ export interface PublishParams {
 }
 
 export interface AmqplibPublishCustomAttributeFunction {
-    (span: Span, publishParams: PublishParams): void;
+    (span: Span, publishParams: PublishParams, isConfirmChannel: boolean): void;
 }
 
-export interface AmqplibConfirmEndCustomAttributeFunction {
+export interface AmqplibConfirmCustomAttributeFunction {
     (span: Span, publishParams: PublishParams, confirmError: any): void;
 }
 
 export interface AmqplibConsumerCustomAttributeFunction {
     (span: Span, msg: amqp.ConsumeMessage | null): void;
+}
+
+export interface AmqplibConsumerEndCustomAttributeFunction {
+    (span: Span, msg: amqp.ConsumeMessage | null, rejected: boolean, endOperation: EndOperation): void;
 }
 
 export enum EndOperation {
@@ -33,19 +37,12 @@ export enum EndOperation {
     InstrumentationTimeout = 'instrumentation timeout',
 }
 
-export interface AmqplibConsumerEndCustomAttributeFunction {
-    (span: Span, msg: amqp.ConsumeMessage | null, rejected: boolean, endOperation: EndOperation): void;
-}
-
 export interface AmqplibInstrumentationConfig extends InstrumentationConfig {
-    /** hook for adding custom attributes before publish message is sent through normal channel */
+    /** hook for adding custom attributes before publish message is sent */
     publishHook?: AmqplibPublishCustomAttributeFunction;
 
-    /** hook for adding custom attributes before publish message is sent through confirm channel */
-    publishConfirmHook?: AmqplibPublishCustomAttributeFunction;
-
     /** hook for adding custom attributes after publish message is confirmed by the broker */
-    publishConfirmEndHook?: AmqplibConfirmEndCustomAttributeFunction;
+    publishConfirmHook?: AmqplibConfirmCustomAttributeFunction;
 
     /** hook for adding custom attributes before consumer message is processed */
     consumeHook?: AmqplibConsumerCustomAttributeFunction;

--- a/packages/instrumentation-amqplib/src/types.ts
+++ b/packages/instrumentation-amqplib/src/types.ts
@@ -23,7 +23,7 @@ export interface AmqplibConsumerCustomAttributeFunction {
 }
 
 export interface AmqplibConsumerEndCustomAttributeFunction {
-    (span: Span, msg: amqp.ConsumeMessage | null, rejected: boolean, endOperation: EndOperation): void;
+    (span: Span, msg: amqp.ConsumeMessage, rejected: boolean, endOperation: EndOperation): void;
 }
 
 export enum EndOperation {
@@ -36,10 +36,6 @@ export enum EndOperation {
     ChannelClosed = 'channel closed',
     ChannelError = 'channel error',
     InstrumentationTimeout = 'instrumentation timeout',
-}
-
-export interface AmqplibConsumerEndCustomAttributeFunction {
-    (span: Span, msg: amqp.ConsumeMessage, rejected: boolean, endOperation: EndOperation): void;
 }
 
 export interface AmqplibInstrumentationConfig extends InstrumentationConfig {

--- a/packages/instrumentation-amqplib/src/types.ts
+++ b/packages/instrumentation-amqplib/src/types.ts
@@ -7,10 +7,11 @@ export interface PublishParams {
     routingKey: string;
     content: Buffer;
     options?: amqp.Options.Publish;
+    isConfirmChannel?: boolean;
 }
 
 export interface AmqplibPublishCustomAttributeFunction {
-    (span: Span, publishParams: PublishParams, isConfirmChannel: boolean): void;
+    (span: Span, publishParams: PublishParams): void;
 }
 
 export interface AmqplibConfirmCustomAttributeFunction {

--- a/packages/instrumentation-amqplib/src/utils.ts
+++ b/packages/instrumentation-amqplib/src/utils.ts
@@ -9,7 +9,7 @@ export const CHANNEL_CONSUME_TIMEOUT_TIMER: unique symbol = Symbol(
 );
 export const CONNECTION_ATTRIBUTES: unique symbol = Symbol('opentelemetry.amqplib.connection.attributes');
 
-export const IS_CONFIRM_CHANNEL: symbol = createContextKey('opentelemetry.amqplib.channel.is-confirm-channel');
+const IS_CONFIRM_CHANNEL_CONTEXT_KEY: symbol = createContextKey('opentelemetry.amqplib.channel.is-confirm-channel');
 
 export const normalizeExchange = (exchangeName: string) => (exchangeName !== '' ? exchangeName : '<default>');
 
@@ -114,6 +114,14 @@ export const getConnectionAttributesFromUrl = (
     return attributes;
 };
 
-export const isConfirmChannel = (context: Context) => {
-    return context.getValue(IS_CONFIRM_CHANNEL) === true;
+export const markConfirmChannelTracing = (context: Context) => {
+    return context.setValue(IS_CONFIRM_CHANNEL_CONTEXT_KEY, true);
+};
+
+export const unmarkConfirmChannelTracing = (context: Context) => {
+    return context.deleteValue(IS_CONFIRM_CHANNEL_CONTEXT_KEY);
+};
+
+export const isConfirmChannelTracing = (context: Context) => {
+    return context.getValue(IS_CONFIRM_CHANNEL_CONTEXT_KEY) === true;
 };

--- a/packages/instrumentation-amqplib/src/utils.ts
+++ b/packages/instrumentation-amqplib/src/utils.ts
@@ -1,4 +1,4 @@
-import { diag, SpanAttributes, SpanAttributeValue } from '@opentelemetry/api';
+import { Context, createContextKey, diag, SpanAttributes, SpanAttributeValue } from '@opentelemetry/api';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import type amqp from 'amqplib';
 
@@ -8,6 +8,8 @@ export const CHANNEL_CONSUME_TIMEOUT_TIMER: unique symbol = Symbol(
     'opentelemetry.amqplib.channel.consumer-timeout-timer'
 );
 export const CONNECTION_ATTRIBUTES: unique symbol = Symbol('opentelemetry.amqplib.connection.attributes');
+
+export const IS_CONFIRM_CHANNEL: symbol = createContextKey('opentelemetry.amqplib.channel.is-confirm-channel');
 
 export const normalizeExchange = (exchangeName: string) => (exchangeName !== '' ? exchangeName : '<default>');
 
@@ -110,4 +112,8 @@ export const getConnectionAttributesFromUrl = (
         }
     }
     return attributes;
+};
+
+export const isConfirmChannel = (context: Context) => {
+    return context.getValue(IS_CONFIRM_CHANNEL) === true;
 };

--- a/packages/instrumentation-amqplib/test/amqplib-callbacks.spec.ts
+++ b/packages/instrumentation-amqplib/test/amqplib-callbacks.spec.ts
@@ -27,103 +27,207 @@ describe('amqplib instrumentation callback model', function () {
         conn.close(() => done());
     });
 
-    let channel: amqpCallback.Channel;
-    beforeEach((done) => {
-        conn.createChannel(
-            context.bind(context.active(), (err, c) => {
-                channel = c;
-                // install an error handler, otherwise when we have tests that create error on the channel,
-                // it throws and crash process
-                channel.on('error', () => {});
-                channel.assertQueue(
-                    queueName,
-                    { durable: false },
-                    context.bind(context.active(), (err, ok) => {
-                        channel.purgeQueue(
-                            queueName,
-                            context.bind(context.active(), (err, ok) => {
-                                done();
-                            })
-                        );
-                    })
-                );
-            })
-        );
-    });
+    describe('channel', () => {
+        let channel: amqpCallback.Channel;
+        beforeEach((done) => {
+            conn.createChannel(
+                context.bind(context.active(), (err, c) => {
+                    channel = c;
+                    // install an error handler, otherwise when we have tests that create error on the channel,
+                    // it throws and crash process
+                    channel.on('error', () => {});
+                    channel.assertQueue(
+                        queueName,
+                        { durable: false },
+                        context.bind(context.active(), (err, ok) => {
+                            channel.purgeQueue(
+                                queueName,
+                                context.bind(context.active(), (err, ok) => {
+                                    done();
+                                })
+                            );
+                        })
+                    );
+                })
+            );
+        });
 
-    afterEach((done) => {
-        try {
-            channel.close((err) => {
+        afterEach((done) => {
+            try {
+                channel.close((err) => {
+                    done();
+                });
+            } catch {}
+        });
+
+        it('simple publish and consume from queue callback', (done) => {
+            const hadSpaceInBuffer = channel.sendToQueue(queueName, Buffer.from(msgPayload));
+            expect(hadSpaceInBuffer).toBeTruthy();
+
+            asyncConsume(channel, queueName, [(msg) => expect(msg.content.toString()).toEqual(msgPayload)], {
+                noAck: true,
+            }).then(() => {
+                const [publishSpan, consumeSpan] = getTestSpans();
+
+                // assert publish span
+                expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('rabbitmq');
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toEqual(
+                    MessagingDestinationKindValues.QUEUE
+                );
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(queueName);
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]).toEqual('AMQP');
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]).toEqual('0.9.1');
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_URL]).toEqual(url);
+                expect(publishSpan.attributes[SemanticAttributes.NET_PEER_NAME]).toEqual(TEST_RABBITMQ_HOST);
+                expect(publishSpan.attributes[SemanticAttributes.NET_PEER_PORT]).toEqual(TEST_RABBITMQ_PORT);
+
+                // assert consume span
+                expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('rabbitmq');
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toEqual(
+                    MessagingDestinationKindValues.QUEUE
+                );
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(queueName);
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]).toEqual('AMQP');
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]).toEqual('0.9.1');
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_URL]).toEqual(url);
+                expect(consumeSpan.attributes[SemanticAttributes.NET_PEER_NAME]).toEqual(TEST_RABBITMQ_HOST);
+                expect(consumeSpan.attributes[SemanticAttributes.NET_PEER_PORT]).toEqual(TEST_RABBITMQ_PORT);
+
+                // assert context propagation
+                expect(consumeSpan.spanContext().traceId).toEqual(publishSpan.spanContext().traceId);
+                expect(consumeSpan.parentSpanId).toEqual(publishSpan.spanContext().spanId);
+
                 done();
             });
-        } catch {}
-    });
+        });
 
-    it('simple publish and consume from queue callback', (done) => {
-        const hadSpaceInBuffer = channel.sendToQueue(queueName, Buffer.from(msgPayload));
-        expect(hadSpaceInBuffer).toBeTruthy();
+        it('end span with ack sync', (done) => {
+            channel.sendToQueue(queueName, Buffer.from(msgPayload));
 
-        asyncConsume(channel, queueName, [(msg) => expect(msg.content.toString()).toEqual(msgPayload)], {
-            noAck: true,
-        }).then(() => {
-            const [publishSpan, consumeSpan] = getTestSpans();
+            asyncConsume(channel, queueName, [(msg) => channel.ack(msg)]).then(() => {
+                // assert consumed message span has ended
+                expect(getTestSpans().length).toBe(2);
+                done();
+            });
+        });
 
-            // assert publish span
-            expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
-            expect(publishSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('rabbitmq');
-            expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
-            expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toEqual(
-                MessagingDestinationKindValues.TOPIC
-            );
-            expect(publishSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(queueName);
-            expect(publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]).toEqual('AMQP');
-            expect(publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]).toEqual('0.9.1');
-            expect(publishSpan.attributes[SemanticAttributes.MESSAGING_URL]).toEqual(url);
-            expect(publishSpan.attributes[SemanticAttributes.NET_PEER_NAME]).toEqual(TEST_RABBITMQ_HOST);
-            expect(publishSpan.attributes[SemanticAttributes.NET_PEER_PORT]).toEqual(TEST_RABBITMQ_PORT);
+        it('end span with ack async', (done) => {
+            channel.sendToQueue(queueName, Buffer.from(msgPayload));
 
-            // assert consume span
-            expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
-            expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('rabbitmq');
-            expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
-            expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toEqual(
-                MessagingDestinationKindValues.TOPIC
-            );
-            expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(queueName);
-            expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]).toEqual('AMQP');
-            expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]).toEqual('0.9.1');
-            expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_URL]).toEqual(url);
-            expect(consumeSpan.attributes[SemanticAttributes.NET_PEER_NAME]).toEqual(TEST_RABBITMQ_HOST);
-            expect(consumeSpan.attributes[SemanticAttributes.NET_PEER_PORT]).toEqual(TEST_RABBITMQ_PORT);
-
-            // assert context propagation
-            expect(consumeSpan.spanContext().traceId).toEqual(publishSpan.spanContext().traceId);
-            expect(consumeSpan.parentSpanId).toEqual(publishSpan.spanContext().spanId);
-
-            done();
+            asyncConsume(channel, queueName, [
+                (msg) =>
+                    setTimeout(() => {
+                        channel.ack(msg);
+                        expect(getTestSpans().length).toBe(2);
+                        done();
+                    }, 1),
+            ]);
         });
     });
 
-    it('end span with ack sync', (done) => {
-        channel.sendToQueue(queueName, Buffer.from(msgPayload));
-
-        asyncConsume(channel, queueName, [(msg) => channel.ack(msg)]).then(() => {
-            // assert consumed message span has ended
-            expect(getTestSpans().length).toBe(2);
-            done();
+    describe('confirm channel', () => {
+        let confirmChannel: amqpCallback.ConfirmChannel;
+        beforeEach((done) => {
+            conn.createConfirmChannel(
+                context.bind(context.active(), (err, c) => {
+                    confirmChannel = c;
+                    // install an error handler, otherwise when we have tests that create error on the channel,
+                    // it throws and crash process
+                    confirmChannel.on('error', () => {});
+                    confirmChannel.assertQueue(
+                        queueName,
+                        { durable: false },
+                        context.bind(context.active(), (err, ok) => {
+                            confirmChannel.purgeQueue(
+                                queueName,
+                                context.bind(context.active(), (err, ok) => {
+                                    done();
+                                })
+                            );
+                        })
+                    );
+                })
+            );
         });
-    });
 
-    it('end span with ack async', (done) => {
-        channel.sendToQueue(queueName, Buffer.from(msgPayload));
-
-        asyncConsume(channel, queueName, [
-            (msg) =>
-                setTimeout(() => {
-                    channel.ack(msg);
-                    expect(getTestSpans().length).toBe(2);
+        afterEach((done) => {
+            try {
+                confirmChannel.close((err) => {
                     done();
-                }, 1),
-        ]);
+                });
+            } catch {}
+        });
+
+        it('simple publish and consume from queue callback', (done) => {
+            const hadSpaceInBuffer = confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload));
+            expect(hadSpaceInBuffer).toBeTruthy();
+
+            asyncConsume(confirmChannel, queueName, [(msg) => expect(msg.content.toString()).toEqual(msgPayload)], {
+                noAck: true,
+            }).then(() => {
+                const [publishSpan, consumeSpan] = getTestSpans();
+
+                // assert publish span
+                expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('rabbitmq');
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toEqual(
+                    MessagingDestinationKindValues.QUEUE
+                );
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(queueName);
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]).toEqual('AMQP');
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]).toEqual('0.9.1');
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_URL]).toEqual(url);
+                expect(publishSpan.attributes[SemanticAttributes.NET_PEER_NAME]).toEqual(TEST_RABBITMQ_HOST);
+                expect(publishSpan.attributes[SemanticAttributes.NET_PEER_PORT]).toEqual(TEST_RABBITMQ_PORT);
+
+                // assert consume span
+                expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('rabbitmq');
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toEqual(
+                    MessagingDestinationKindValues.QUEUE
+                );
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(queueName);
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]).toEqual('AMQP');
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]).toEqual('0.9.1');
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_URL]).toEqual(url);
+                expect(consumeSpan.attributes[SemanticAttributes.NET_PEER_NAME]).toEqual(TEST_RABBITMQ_HOST);
+                expect(consumeSpan.attributes[SemanticAttributes.NET_PEER_PORT]).toEqual(TEST_RABBITMQ_PORT);
+
+                // assert context propagation
+                expect(consumeSpan.spanContext().traceId).toEqual(publishSpan.spanContext().traceId);
+                expect(consumeSpan.parentSpanId).toEqual(publishSpan.spanContext().spanId);
+
+                done();
+            });
+        });
+
+        it('end span with ack sync', (done) => {
+            confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+            asyncConsume(confirmChannel, queueName, [(msg) => confirmChannel.ack(msg)]).then(() => {
+                // assert consumed message span has ended
+                expect(getTestSpans().length).toBe(2);
+                done();
+            });
+        });
+
+        it('end span with ack async', (done) => {
+            confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+            asyncConsume(confirmChannel, queueName, [
+                (msg) =>
+                    setTimeout(() => {
+                        confirmChannel.ack(msg);
+                        expect(getTestSpans().length).toBe(2);
+                        done();
+                    }, 1),
+            ]);
+        });
     });
 });

--- a/packages/instrumentation-amqplib/test/amqplib-callbacks.spec.ts
+++ b/packages/instrumentation-amqplib/test/amqplib-callbacks.spec.ts
@@ -74,7 +74,7 @@ describe('amqplib instrumentation callback model', function () {
                 expect(publishSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('rabbitmq');
                 expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
                 expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toEqual(
-                    MessagingDestinationKindValues.QUEUE
+                    MessagingDestinationKindValues.TOPIC
                 );
                 expect(publishSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(queueName);
                 expect(publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]).toEqual('AMQP');
@@ -88,7 +88,7 @@ describe('amqplib instrumentation callback model', function () {
                 expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('rabbitmq');
                 expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
                 expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toEqual(
-                    MessagingDestinationKindValues.QUEUE
+                    MessagingDestinationKindValues.TOPIC
                 );
                 expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(queueName);
                 expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]).toEqual('AMQP');
@@ -174,7 +174,7 @@ describe('amqplib instrumentation callback model', function () {
                     expect(publishSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('rabbitmq');
                     expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
                     expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toEqual(
-                        MessagingDestinationKindValues.QUEUE
+                        MessagingDestinationKindValues.TOPIC
                     );
                     expect(publishSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(
                         queueName
@@ -190,7 +190,7 @@ describe('amqplib instrumentation callback model', function () {
                     expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('rabbitmq');
                     expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
                     expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toEqual(
-                        MessagingDestinationKindValues.QUEUE
+                        MessagingDestinationKindValues.TOPIC
                     );
                     expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(
                         queueName

--- a/packages/instrumentation-amqplib/test/amqplib-connection.spec.ts
+++ b/packages/instrumentation-amqplib/test/amqplib-connection.spec.ts
@@ -2,7 +2,7 @@ import 'mocha';
 import expect from 'expect';
 import { TEST_RABBITMQ_HOST, TEST_RABBITMQ_PORT } from './config';
 import { AmqplibInstrumentation } from '../src';
-import { getTestSpans, registerInstrumentation } from '../../instrumentation-testing-utils/dist/src';
+import { getTestSpans, registerInstrumentation } from 'opentelemetry-instrumentation-testing-utils';
 
 const instrumentation = registerInstrumentation(new AmqplibInstrumentation());
 import amqp from 'amqplib';

--- a/packages/instrumentation-amqplib/test/amqplib-promise.spec.ts
+++ b/packages/instrumentation-amqplib/test/amqplib-promise.spec.ts
@@ -490,9 +490,11 @@ describe('amqplib instrumentation promise model', function () {
             }
         });
 
-        it('simple publish and consume from queue', async () => {
-            const hadSpaceInBuffer = confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload));
-            expect(hadSpaceInBuffer).toBeTruthy();
+        it('simple publish with confirm and consume from queue', async () => {
+            await new Promise<void>(resolve => {
+                const hadSpaceInBuffer = confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload), {}, err => resolve());
+                expect(hadSpaceInBuffer).toBeTruthy();
+            });
 
             await asyncConsume(
                 confirmChannel,

--- a/packages/instrumentation-amqplib/test/amqplib-promise.spec.ts
+++ b/packages/instrumentation-amqplib/test/amqplib-promise.spec.ts
@@ -847,12 +847,12 @@ describe('amqplib instrumentation promise model', function () {
                 const attributeNameFromConsumeEndHook = 'attribute.name.from.consume.endhook';
                 const consumeEndHookAttributeValue = 'attribute value from consume end hook';
                 instrumentation.setConfig({
-                    publishHook: (span: Span, publishParams: PublishParams, isConfirmChannel: boolean): void => {
+                    publishHook: (span: Span, publishParams: PublishParams) => {
                         span.setAttribute(attributeNameFromHook, hookAttributeValue);
                         expect(publishParams.exchange).toEqual('');
                         expect(publishParams.routingKey).toEqual(queueName);
                         expect(publishParams.content.toString()).toEqual(msgPayload);
-                        expect(isConfirmChannel).toBe(true);
+                        expect(publishParams.isConfirmChannel).toBe(true);
                     },
                     publishConfirmHook: (span, publishParams) => {
                         span.setAttribute(attributeNameFromConfirmEndHook, confirmEndHookAttributeValue);
@@ -860,7 +860,7 @@ describe('amqplib instrumentation promise model', function () {
                         expect(publishParams.routingKey).toEqual(queueName);
                         expect(publishParams.content.toString()).toEqual(msgPayload);
                     },
-                    consumeHook: (span: Span, msg: amqp.ConsumeMessage | null): void => {
+                    consumeHook: (span: Span, msg: amqp.ConsumeMessage | null) => {
                         span.setAttribute(attributeNameFromHook, hookAttributeValue);
                         expect(msg.content.toString()).toEqual(msgPayload);
                     },
@@ -895,7 +895,7 @@ describe('amqplib instrumentation promise model', function () {
                 const attributeNameFromHook = 'attribute.name.from.hook';
                 const hookAttributeValue = 'attribute value from hook';
                 instrumentation.setConfig({
-                    publishHook: (span: Span, publishParams: PublishParams, isConfirmChannel: boolean): void => {
+                    publishHook: (span: Span, publishParams: PublishParams): void => {
                         span.setAttribute(attributeNameFromHook, hookAttributeValue);
                         throw new Error('error from hook');
                     },

--- a/packages/instrumentation-amqplib/test/amqplib-promise.spec.ts
+++ b/packages/instrumentation-amqplib/test/amqplib-promise.spec.ts
@@ -3,7 +3,7 @@ import expect from 'expect';
 import sinon from 'sinon';
 import lodash from 'lodash';
 import { AmqplibInstrumentation, EndOperation, PublishParams } from '../src';
-import { getTestSpans, registerInstrumentation } from '../../instrumentation-testing-utils/dist/src';
+import { getTestSpans, registerInstrumentation } from 'opentelemetry-instrumentation-testing-utils';
 
 const instrumentation = registerInstrumentation(new AmqplibInstrumentation());
 
@@ -53,409 +53,852 @@ describe('amqplib instrumentation promise model', function () {
         });
     };
 
-    let channel: amqp.Channel;
-    beforeEach(async () => {
-        endHookSpy = sinon.spy();
-        instrumentation.setConfig({
-            consumeEndHook: endHookSpy,
-        });
-
-        channel = await conn.createChannel();
-        await channel.assertQueue(queueName, { durable: false });
-        await channel.purgeQueue(queueName);
-        // install an error handler, otherwise when we have tests that create error on the channel,
-        // it throws and crash process
-        channel.on('error', (err) => {});
-    });
-    afterEach(async () => {
-        if (!channel[CHANNEL_CLOSED_IN_TEST]) {
-            try {
-                await new Promise<void>((resolve) => {
-                    channel.on('close', resolve);
-                    channel.close();
-                });
-            } catch {}
-        }
-    });
-
-    it('simple publish and consume from queue', async () => {
-        const hadSpaceInBuffer = channel.sendToQueue(queueName, Buffer.from(msgPayload));
-        expect(hadSpaceInBuffer).toBeTruthy();
-
-        await asyncConsume(channel, queueName, [(msg) => expect(msg.content.toString()).toEqual(msgPayload)], {
-            noAck: true,
-        });
-        const [publishSpan, consumeSpan] = getTestSpans();
-
-        // assert publish span
-        expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
-        expect(publishSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('rabbitmq');
-        expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
-        expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toEqual(
-            MessagingDestinationKindValues.TOPIC
-        );
-        expect(publishSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(queueName);
-        expect(publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]).toEqual('AMQP');
-        expect(publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]).toEqual('0.9.1');
-        expect(publishSpan.attributes[SemanticAttributes.MESSAGING_URL]).toEqual(url);
-        expect(publishSpan.attributes[SemanticAttributes.NET_PEER_NAME]).toEqual(TEST_RABBITMQ_HOST);
-        expect(publishSpan.attributes[SemanticAttributes.NET_PEER_PORT]).toEqual(TEST_RABBITMQ_PORT);
-
-        // assert consume span
-        expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
-        expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('rabbitmq');
-        expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
-        expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toEqual(
-            MessagingDestinationKindValues.TOPIC
-        );
-        expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(queueName);
-        expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]).toEqual('AMQP');
-        expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]).toEqual('0.9.1');
-        expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_URL]).toEqual(url);
-        expect(consumeSpan.attributes[SemanticAttributes.NET_PEER_NAME]).toEqual(TEST_RABBITMQ_HOST);
-        expect(consumeSpan.attributes[SemanticAttributes.NET_PEER_PORT]).toEqual(TEST_RABBITMQ_PORT);
-
-        // assert context propagation
-        expect(consumeSpan.spanContext().traceId).toEqual(publishSpan.spanContext().traceId);
-        expect(consumeSpan.parentSpanId).toEqual(publishSpan.spanContext().spanId);
-
-        expectConsumeEndSpyStatus([EndOperation.AutoAck]);
-    });
-
-    describe('ending consume spans', () => {
-        it('message acked sync', async () => {
-            channel.sendToQueue(queueName, Buffer.from(msgPayload));
-
-            await asyncConsume(channel, queueName, [(msg) => channel.ack(msg)]);
-            // assert consumed message span has ended
-            expect(getTestSpans().length).toBe(2);
-            expectConsumeEndSpyStatus([EndOperation.Ack]);
-        });
-
-        it('message acked async', async () => {
-            channel.sendToQueue(queueName, Buffer.from(msgPayload));
-
-            // start async timer and ack the message after the callback returns
-            await new Promise<void>((resolve) => {
-                asyncConsume(channel, queueName, [
-                    (msg) =>
-                        setTimeout(() => {
-                            channel.ack(msg);
-                            resolve();
-                        }, 1),
-                ]);
-            });
-            // assert consumed message span has ended
-            expect(getTestSpans().length).toBe(2);
-            expectConsumeEndSpyStatus([EndOperation.Ack]);
-        });
-
-        it('message nack no requeue', async () => {
-            channel.sendToQueue(queueName, Buffer.from(msgPayload));
-
-            await asyncConsume(channel, queueName, [(msg) => channel.nack(msg, false, false)]);
-            await new Promise((resolve) => setTimeout(resolve, 20)); // just make sure we don't get it again
-            // assert consumed message span has ended
-            expect(getTestSpans().length).toBe(2);
-            const [_, consumerSpan] = getTestSpans();
-            expect(consumerSpan.status.code).toEqual(SpanStatusCode.ERROR);
-            expect(consumerSpan.status.message).toEqual('nack called on message without requeue');
-            expectConsumeEndSpyStatus([EndOperation.Nack]);
-        });
-
-        it('message nack requeue, then acked', async () => {
-            channel.sendToQueue(queueName, Buffer.from(msgPayload));
-
-            // @ts-ignore
-            await asyncConsume(channel, queueName, [
-                (msg: amqp.Message) => channel.nack(msg, false, true),
-                (msg: amqp.Message) => channel.ack(msg),
-            ]);
-            // assert we have the requeued message sent again
-            expect(getTestSpans().length).toBe(3);
-            const [_, rejectedConsumerSpan, successConsumerSpan] = getTestSpans();
-            expect(rejectedConsumerSpan.status.code).toEqual(SpanStatusCode.ERROR);
-            expect(rejectedConsumerSpan.status.message).toEqual('nack called on message with requeue');
-            expect(successConsumerSpan.status.code).toEqual(SpanStatusCode.UNSET);
-            expectConsumeEndSpyStatus([EndOperation.Nack, EndOperation.Ack]);
-        });
-
-        it('ack allUpTo 2 msgs sync', async () => {
-            lodash.times(3, () => channel.sendToQueue(queueName, Buffer.from(msgPayload)));
-
-            // @ts-ignore
-            await asyncConsume(channel, queueName, [null, (msg) => channel.ack(msg, true), (msg) => channel.ack(msg)]);
-            // assert all 3 messages are acked, including the first one which is acked by allUpTo
-            expect(getTestSpans().length).toBe(6);
-            expectConsumeEndSpyStatus([EndOperation.Ack, EndOperation.Ack, EndOperation.Ack]);
-        });
-
-        it('nack allUpTo 2 msgs sync', async () => {
-            lodash.times(3, () => channel.sendToQueue(queueName, Buffer.from(msgPayload)));
-
-            // @ts-ignore
-            await asyncConsume(channel, queueName, [
-                null,
-                (msg) => channel.nack(msg, true, false),
-                (msg) => channel.nack(msg, false, false),
-            ]);
-            // assert all 3 messages are acked, including the first one which is acked by allUpTo
-            expect(getTestSpans().length).toBe(6);
-            lodash.range(3, 6).forEach((i) => {
-                expect(getTestSpans()[i].status.code).toEqual(SpanStatusCode.ERROR);
-                expect(getTestSpans()[i].status.message).toEqual('nack called on message without requeue');
-            });
-            expectConsumeEndSpyStatus([EndOperation.Nack, EndOperation.Nack, EndOperation.Nack]);
-        });
-
-        it('ack not in received order', async () => {
-            lodash.times(3, () => channel.sendToQueue(queueName, Buffer.from(msgPayload)));
-
-            // @ts-ignore
-            const msgs = await asyncConsume(channel, queueName, [null, null, null]);
-            channel.ack(msgs[1]);
-            channel.ack(msgs[2]);
-            channel.ack(msgs[0]);
-            // assert all 3 span messages are ended
-            expect(getTestSpans().length).toBe(6);
-            expectConsumeEndSpyStatus([EndOperation.Ack, EndOperation.Ack, EndOperation.Ack]);
-        });
-
-        it('ackAll', async () => {
-            lodash.times(2, () => channel.sendToQueue(queueName, Buffer.from(msgPayload)));
-
-            // @ts-ignore
-            await asyncConsume(channel, queueName, [null, () => channel.ackAll()]);
-            // assert all 2 span messages are ended by call to ackAll
-            expect(getTestSpans().length).toBe(4);
-            expectConsumeEndSpyStatus([EndOperation.AckAll, EndOperation.AckAll]);
-        });
-
-        it('nackAll', async () => {
-            lodash.times(2, () => channel.sendToQueue(queueName, Buffer.from(msgPayload)));
-
-            // @ts-ignore
-            await asyncConsume(channel, queueName, [null, () => channel.nackAll(false)]);
-            // assert all 2 span messages are ended by calling nackAll
-            expect(getTestSpans().length).toBe(4);
-            lodash.range(2, 4).forEach((i) => {
-                expect(getTestSpans()[i].status.code).toEqual(SpanStatusCode.ERROR);
-                expect(getTestSpans()[i].status.message).toEqual('nackAll called on message without requeue');
-            });
-            expectConsumeEndSpyStatus([EndOperation.NackAll, EndOperation.NackAll]);
-        });
-
-        it('reject', async () => {
-            lodash.times(1, () => channel.sendToQueue(queueName, Buffer.from(msgPayload)));
-
-            // @ts-ignore
-            await asyncConsume(channel, queueName, [(msg) => channel.reject(msg, false)]);
-            expect(getTestSpans().length).toBe(2);
-            expect(getTestSpans()[1].status.code).toEqual(SpanStatusCode.ERROR);
-            expect(getTestSpans()[1].status.message).toEqual('reject called on message without requeue');
-            expectConsumeEndSpyStatus([EndOperation.Reject]);
-        });
-
-        it('reject with requeue', async () => {
-            lodash.times(1, () => channel.sendToQueue(queueName, Buffer.from(msgPayload)));
-
-            // @ts-ignore
-            await asyncConsume(channel, queueName, [
-                (msg) => channel.reject(msg, true),
-                (msg) => channel.reject(msg, false),
-            ]);
-            expect(getTestSpans().length).toBe(3);
-            expect(getTestSpans()[1].status.code).toEqual(SpanStatusCode.ERROR);
-            expect(getTestSpans()[1].status.message).toEqual('reject called on message with requeue');
-            expect(getTestSpans()[2].status.code).toEqual(SpanStatusCode.ERROR);
-            expect(getTestSpans()[2].status.message).toEqual('reject called on message without requeue');
-            expectConsumeEndSpyStatus([EndOperation.Reject, EndOperation.Reject]);
-        });
-
-        it('closing channel should end all open spans on it', async () => {
-            lodash.times(1, () => channel.sendToQueue(queueName, Buffer.from(msgPayload)));
-
-            await new Promise<void>((resolve) =>
-                asyncConsume(channel, queueName, [
-                    async (msg) => {
-                        await channel.close();
-                        resolve();
-                        channel[CHANNEL_CLOSED_IN_TEST] = true;
-                    },
-                ])
-            );
-
-            expect(getTestSpans().length).toBe(2);
-            expect(getTestSpans()[1].status.code).toEqual(SpanStatusCode.ERROR);
-            expect(getTestSpans()[1].status.message).toEqual('channel closed');
-            expectConsumeEndSpyStatus([EndOperation.ChannelClosed]);
-        });
-
-        it('error on channel should end all open spans on it', (done) => {
-            lodash.times(2, () => channel.sendToQueue(queueName, Buffer.from(msgPayload)));
-
-            channel.on('close', () => {
-                expect(getTestSpans().length).toBe(4);
-                // second consume ended with valid ack, previous message not acked when channel is errored.
-                // since we first ack the second message, it appear first in the finished spans array
-                expect(getTestSpans()[2].status.code).toEqual(SpanStatusCode.UNSET);
-                expect(getTestSpans()[3].status.code).toEqual(SpanStatusCode.ERROR);
-                expect(getTestSpans()[3].status.message).toEqual('channel error');
-                expectConsumeEndSpyStatus([EndOperation.Ack, EndOperation.ChannelError]);
-                done();
-            });
-            asyncConsume(channel, queueName, [
-                null,
-                (msg) => {
-                    try {
-                        channel.ack(msg);
-                        channel[CHANNEL_CLOSED_IN_TEST] = true;
-                        // ack the same msg again, this is not valid and should close the channel
-                        channel.ack(msg);
-                    } catch {}
-                },
-            ]);
-        });
-
-        it('not acking the message trigger timeout', async () => {
+    describe('channel', () => {
+        let channel: amqp.Channel;
+        beforeEach(async () => {
+            endHookSpy = sinon.spy();
             instrumentation.setConfig({
                 consumeEndHook: endHookSpy,
-                consumeTimeoutMs: 1,
             });
 
-            lodash.times(1, () => channel.sendToQueue(queueName, Buffer.from(msgPayload)));
-
-            await asyncConsume(channel, queueName, [null]);
-
-            // we have timeout of 1 ms, so we wait more than that and check span indeed ended
-            await new Promise((resolve) => setTimeout(resolve, 10));
-
-            expect(getTestSpans().length).toBe(2);
-            expectConsumeEndSpyStatus([EndOperation.InstrumentationTimeout]);
+            channel = await conn.createChannel();
+            await channel.assertQueue(queueName, { durable: false });
+            await channel.purgeQueue(queueName);
+            // install an error handler, otherwise when we have tests that create error on the channel,
+            // it throws and crash process
+            channel.on('error', (err) => {});
         });
-    });
+        afterEach(async () => {
+            if (!channel[CHANNEL_CLOSED_IN_TEST]) {
+                try {
+                    await new Promise<void>((resolve) => {
+                        channel.on('close', resolve);
+                        channel.close();
+                    });
+                } catch {}
+            }
+        });
 
-    describe('routing and exchange', () => {
-        it('topic exchange', async () => {
-            const exchangeName = 'topic exchange';
-            const routingKey = 'topic.name.from.unittest';
-            await channel.assertExchange(exchangeName, 'topic', { durable: false });
+        it('simple publish and consume from queue', async () => {
+            const hadSpaceInBuffer = channel.sendToQueue(queueName, Buffer.from(msgPayload));
+            expect(hadSpaceInBuffer).toBeTruthy();
 
-            const { queue: queueName } = await channel.assertQueue('', { durable: false });
-            await channel.bindQueue(queueName, exchangeName, '#');
-
-            const consumerPromise = asyncConsume(channel, queueName, [null], {
+            await asyncConsume(channel, queueName, [(msg) => expect(msg.content.toString()).toEqual(msgPayload)], {
                 noAck: true,
             });
-
-            channel.publish(exchangeName, routingKey, Buffer.from(msgPayload));
-            await consumerPromise;
-
             const [publishSpan, consumeSpan] = getTestSpans();
 
             // assert publish span
             expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
             expect(publishSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('rabbitmq');
-            expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(exchangeName);
+            expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
             expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toEqual(
-                MessagingDestinationKindValues.TOPIC
+                MessagingDestinationKindValues.QUEUE
             );
-            expect(publishSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(routingKey);
+            expect(publishSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(queueName);
             expect(publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]).toEqual('AMQP');
             expect(publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]).toEqual('0.9.1');
+            expect(publishSpan.attributes[SemanticAttributes.MESSAGING_URL]).toEqual(url);
+            expect(publishSpan.attributes[SemanticAttributes.NET_PEER_NAME]).toEqual(TEST_RABBITMQ_HOST);
+            expect(publishSpan.attributes[SemanticAttributes.NET_PEER_PORT]).toEqual(TEST_RABBITMQ_PORT);
 
             // assert consume span
             expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
             expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('rabbitmq');
-            expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(exchangeName);
+            expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
             expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toEqual(
-                MessagingDestinationKindValues.TOPIC
+                MessagingDestinationKindValues.QUEUE
             );
-            expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(routingKey);
+            expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(queueName);
             expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]).toEqual('AMQP');
             expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]).toEqual('0.9.1');
+            expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_URL]).toEqual(url);
+            expect(consumeSpan.attributes[SemanticAttributes.NET_PEER_NAME]).toEqual(TEST_RABBITMQ_HOST);
+            expect(consumeSpan.attributes[SemanticAttributes.NET_PEER_PORT]).toEqual(TEST_RABBITMQ_PORT);
 
             // assert context propagation
             expect(consumeSpan.spanContext().traceId).toEqual(publishSpan.spanContext().traceId);
             expect(consumeSpan.parentSpanId).toEqual(publishSpan.spanContext().spanId);
-        });
-    });
 
-    it('moduleVersionAttributeName works with publish and consume', async () => {
-        const VERSION_ATTR = 'module.version';
-        instrumentation.setConfig({
-            moduleVersionAttributeName: VERSION_ATTR,
+            expectConsumeEndSpyStatus([EndOperation.AutoAck]);
         });
 
-        channel.sendToQueue(queueName, Buffer.from(msgPayload));
+        describe('ending consume spans', () => {
+            it('message acked sync', async () => {
+                channel.sendToQueue(queueName, Buffer.from(msgPayload));
 
-        await asyncConsume(channel, queueName, [(msg) => expect(msg.content.toString()).toEqual(msgPayload)], {
-            noAck: true,
+                await asyncConsume(channel, queueName, [(msg) => channel.ack(msg)]);
+                // assert consumed message span has ended
+                expect(getTestSpans().length).toBe(2);
+                expectConsumeEndSpyStatus([EndOperation.Ack]);
+            });
+
+            it('message acked async', async () => {
+                channel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+                // start async timer and ack the message after the callback returns
+                await new Promise<void>((resolve) => {
+                    asyncConsume(channel, queueName, [
+                        (msg) =>
+                            setTimeout(() => {
+                                channel.ack(msg);
+                                resolve();
+                            }, 1),
+                    ]);
+                });
+                // assert consumed message span has ended
+                expect(getTestSpans().length).toBe(2);
+                expectConsumeEndSpyStatus([EndOperation.Ack]);
+            });
+
+            it('message nack no requeue', async () => {
+                channel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+                await asyncConsume(channel, queueName, [(msg) => channel.nack(msg, false, false)]);
+                await new Promise((resolve) => setTimeout(resolve, 20)); // just make sure we don't get it again
+                // assert consumed message span has ended
+                expect(getTestSpans().length).toBe(2);
+                const [_, consumerSpan] = getTestSpans();
+                expect(consumerSpan.status.code).toEqual(SpanStatusCode.ERROR);
+                expect(consumerSpan.status.message).toEqual('nack called on message without requeue');
+                expectConsumeEndSpyStatus([EndOperation.Nack]);
+            });
+
+            it('message nack requeue, then acked', async () => {
+                channel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+                // @ts-ignore
+                await asyncConsume(channel, queueName, [
+                    (msg: amqp.Message) => channel.nack(msg, false, true),
+                    (msg: amqp.Message) => channel.ack(msg),
+                ]);
+                // assert we have the requeued message sent again
+                expect(getTestSpans().length).toBe(3);
+                const [_, rejectedConsumerSpan, successConsumerSpan] = getTestSpans();
+                expect(rejectedConsumerSpan.status.code).toEqual(SpanStatusCode.ERROR);
+                expect(rejectedConsumerSpan.status.message).toEqual('nack called on message with requeue');
+                expect(successConsumerSpan.status.code).toEqual(SpanStatusCode.OK);
+                expectConsumeEndSpyStatus([EndOperation.Nack, EndOperation.Ack]);
+            });
+
+            it('ack allUpTo 2 msgs sync', async () => {
+                lodash.times(3, () => channel.sendToQueue(queueName, Buffer.from(msgPayload)));
+
+                // @ts-ignore
+                await asyncConsume(channel, queueName, [
+                    null,
+                    (msg) => channel.ack(msg, true),
+                    (msg) => channel.ack(msg),
+                ]);
+                // assert all 3 messages are acked, including the first one which is acked by allUpTo
+                expect(getTestSpans().length).toBe(6);
+                expectConsumeEndSpyStatus([EndOperation.Ack, EndOperation.Ack, EndOperation.Ack]);
+            });
+
+            it('nack allUpTo 2 msgs sync', async () => {
+                lodash.times(3, () => channel.sendToQueue(queueName, Buffer.from(msgPayload)));
+
+                // @ts-ignore
+                await asyncConsume(channel, queueName, [
+                    null,
+                    (msg) => channel.nack(msg, true, false),
+                    (msg) => channel.nack(msg, false, false),
+                ]);
+                // assert all 3 messages are acked, including the first one which is acked by allUpTo
+                expect(getTestSpans().length).toBe(6);
+                lodash.range(3, 6).forEach((i) => {
+                    expect(getTestSpans()[i].status.code).toEqual(SpanStatusCode.ERROR);
+                    expect(getTestSpans()[i].status.message).toEqual('nack called on message without requeue');
+                });
+                expectConsumeEndSpyStatus([EndOperation.Nack, EndOperation.Nack, EndOperation.Nack]);
+            });
+
+            it('ack not in received order', async () => {
+                lodash.times(3, () => channel.sendToQueue(queueName, Buffer.from(msgPayload)));
+
+                // @ts-ignore
+                const msgs = await asyncConsume(channel, queueName, [null, null, null]);
+                channel.ack(msgs[1]);
+                channel.ack(msgs[2]);
+                channel.ack(msgs[0]);
+                // assert all 3 span messages are ended
+                expect(getTestSpans().length).toBe(6);
+                expectConsumeEndSpyStatus([EndOperation.Ack, EndOperation.Ack, EndOperation.Ack]);
+            });
+
+            it('ackAll', async () => {
+                lodash.times(2, () => channel.sendToQueue(queueName, Buffer.from(msgPayload)));
+
+                // @ts-ignore
+                await asyncConsume(channel, queueName, [null, () => channel.ackAll()]);
+                // assert all 2 span messages are ended by call to ackAll
+                expect(getTestSpans().length).toBe(4);
+                expectConsumeEndSpyStatus([EndOperation.AckAll, EndOperation.AckAll]);
+            });
+
+            it('nackAll', async () => {
+                lodash.times(2, () => channel.sendToQueue(queueName, Buffer.from(msgPayload)));
+
+                // @ts-ignore
+                await asyncConsume(channel, queueName, [null, () => channel.nackAll(false)]);
+                // assert all 2 span messages are ended by calling nackAll
+                expect(getTestSpans().length).toBe(4);
+                lodash.range(2, 4).forEach((i) => {
+                    expect(getTestSpans()[i].status.code).toEqual(SpanStatusCode.ERROR);
+                    expect(getTestSpans()[i].status.message).toEqual('nackAll called on message without requeue');
+                });
+                expectConsumeEndSpyStatus([EndOperation.NackAll, EndOperation.NackAll]);
+            });
+
+            it('reject', async () => {
+                lodash.times(1, () => channel.sendToQueue(queueName, Buffer.from(msgPayload)));
+
+                // @ts-ignore
+                await asyncConsume(channel, queueName, [(msg) => channel.reject(msg, false)]);
+                expect(getTestSpans().length).toBe(2);
+                expect(getTestSpans()[1].status.code).toEqual(SpanStatusCode.ERROR);
+                expect(getTestSpans()[1].status.message).toEqual('reject called on message without requeue');
+                expectConsumeEndSpyStatus([EndOperation.Reject]);
+            });
+
+            it('reject with requeue', async () => {
+                lodash.times(1, () => channel.sendToQueue(queueName, Buffer.from(msgPayload)));
+
+                // @ts-ignore
+                await asyncConsume(channel, queueName, [
+                    (msg) => channel.reject(msg, true),
+                    (msg) => channel.reject(msg, false),
+                ]);
+                expect(getTestSpans().length).toBe(3);
+                expect(getTestSpans()[1].status.code).toEqual(SpanStatusCode.ERROR);
+                expect(getTestSpans()[1].status.message).toEqual('reject called on message with requeue');
+                expect(getTestSpans()[2].status.code).toEqual(SpanStatusCode.ERROR);
+                expect(getTestSpans()[2].status.message).toEqual('reject called on message without requeue');
+                expectConsumeEndSpyStatus([EndOperation.Reject, EndOperation.Reject]);
+            });
+
+            it('closing channel should end all open spans on it', async () => {
+                lodash.times(1, () => channel.sendToQueue(queueName, Buffer.from(msgPayload)));
+
+                await new Promise<void>((resolve) =>
+                    asyncConsume(channel, queueName, [
+                        async (msg) => {
+                            await channel.close();
+                            resolve();
+                            channel[CHANNEL_CLOSED_IN_TEST] = true;
+                        },
+                    ])
+                );
+
+                expect(getTestSpans().length).toBe(2);
+                expect(getTestSpans()[1].status.code).toEqual(SpanStatusCode.ERROR);
+                expect(getTestSpans()[1].status.message).toEqual('channel closed');
+                expectConsumeEndSpyStatus([EndOperation.ChannelClosed]);
+            });
+
+            it('error on channel should end all open spans on it', (done) => {
+                lodash.times(2, () => channel.sendToQueue(queueName, Buffer.from(msgPayload)));
+
+                channel.on('close', () => {
+                    expect(getTestSpans().length).toBe(4);
+                    // second consume ended with valid ack, previous message not acked when channel is errored.
+                    // since we first ack the second message, it appear first in the finished spans array
+                    expect(getTestSpans()[2].status.code).toEqual(SpanStatusCode.OK);
+                    expect(getTestSpans()[3].status.code).toEqual(SpanStatusCode.ERROR);
+                    expect(getTestSpans()[3].status.message).toEqual('channel error');
+                    expectConsumeEndSpyStatus([EndOperation.Ack, EndOperation.ChannelError]);
+                    done();
+                });
+                asyncConsume(channel, queueName, [
+                    null,
+                    (msg) => {
+                        try {
+                            channel.ack(msg);
+                            channel[CHANNEL_CLOSED_IN_TEST] = true;
+                            // ack the same msg again, this is not valid and should close the channel
+                            channel.ack(msg);
+                        } catch {}
+                    },
+                ]);
+            });
+
+            it('not acking the message trigger timeout', async () => {
+                instrumentation.setConfig({
+                    consumeEndHook: endHookSpy,
+                    consumeTimeoutMs: 1,
+                });
+
+                lodash.times(1, () => channel.sendToQueue(queueName, Buffer.from(msgPayload)));
+
+                await asyncConsume(channel, queueName, [null]);
+
+                // we have timeout of 1 ms, so we wait more than that and check span indeed ended
+                await new Promise((resolve) => setTimeout(resolve, 10));
+
+                expect(getTestSpans().length).toBe(2);
+                expectConsumeEndSpyStatus([EndOperation.InstrumentationTimeout]);
+            });
         });
-        expect(getTestSpans().length).toBe(2);
-        getTestSpans().forEach((s) => expect(s.attributes[VERSION_ATTR]).toMatch(/\d{1,4}\.\d{1,4}\.\d{1,5}.*/));
-    });
 
-    describe('hooks', () => {
-        it('publish and consume hooks success', async () => {
-            const attributeNameFromHook = 'attribute.name.from.hook';
-            const hookAttributeValue = 'attribute value from hook';
-            const attributeNameFromEndHook = 'attribute.name.from.endhook';
-            const endHookAttributeValue = 'attribute value from end hook';
+        describe('routing and exchange', () => {
+            it('topic exchange', async () => {
+                const exchangeName = 'topic exchange';
+                const routingKey = 'topic.name.from.unittest';
+                await channel.assertExchange(exchangeName, 'topic', { durable: false });
+
+                const { queue: queueName } = await channel.assertQueue('', { durable: false });
+                await channel.bindQueue(queueName, exchangeName, '#');
+
+                channel.publish(exchangeName, routingKey, Buffer.from(msgPayload));
+
+                await asyncConsume(channel, queueName, [null], {
+                    noAck: true,
+                });
+
+                const [publishSpan, consumeSpan] = getTestSpans();
+
+                // assert publish span
+                expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('rabbitmq');
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(exchangeName);
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toEqual(
+                    MessagingDestinationKindValues.QUEUE
+                );
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(routingKey);
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]).toEqual('AMQP');
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]).toEqual('0.9.1');
+
+                // assert consume span
+                expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('rabbitmq');
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(exchangeName);
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toEqual(
+                    MessagingDestinationKindValues.QUEUE
+                );
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(routingKey);
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]).toEqual('AMQP');
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]).toEqual('0.9.1');
+
+                // assert context propagation
+                expect(consumeSpan.spanContext().traceId).toEqual(publishSpan.spanContext().traceId);
+                expect(consumeSpan.parentSpanId).toEqual(publishSpan.spanContext().spanId);
+            });
+        });
+
+        it('moduleVersionAttributeName works with publish and consume', async () => {
+            const VERSION_ATTR = 'module.version';
             instrumentation.setConfig({
-                publishHook: (span: Span, publishParams: PublishParams): void => {
-                    span.setAttribute(attributeNameFromHook, hookAttributeValue);
-                    expect(publishParams.exchange).toEqual('');
-                    expect(publishParams.routingKey).toEqual(queueName);
-                    expect(publishParams.content.toString()).toEqual(msgPayload);
-                },
-                consumeHook: (span: Span, msg: amqp.ConsumeMessage | null): void => {
-                    span.setAttribute(attributeNameFromHook, hookAttributeValue);
-                    expect(msg.content.toString()).toEqual(msgPayload);
-                },
-                consumeEndHook: (
-                    span: Span,
-                    msg: amqp.ConsumeMessage | null,
-                    rejected: boolean,
-                    endOperation: EndOperation
-                ): void => {
-                    span.setAttribute(attributeNameFromEndHook, endHookAttributeValue);
-                    expect(endOperation).toEqual(EndOperation.AutoAck);
-                },
+                moduleVersionAttributeName: VERSION_ATTR,
             });
 
             channel.sendToQueue(queueName, Buffer.from(msgPayload));
 
-            await asyncConsume(channel, queueName, [null], {
+            await asyncConsume(channel, queueName, [(msg) => expect(msg.content.toString()).toEqual(msgPayload)], {
                 noAck: true,
             });
             expect(getTestSpans().length).toBe(2);
-            expect(getTestSpans()[0].attributes[attributeNameFromHook]).toEqual(hookAttributeValue);
-            expect(getTestSpans()[1].attributes[attributeNameFromHook]).toEqual(hookAttributeValue);
-            expect(getTestSpans()[1].attributes[attributeNameFromEndHook]).toEqual(endHookAttributeValue);
+            getTestSpans().forEach((s) => expect(s.attributes[VERSION_ATTR]).toMatch(/\d{1,4}\.\d{1,4}\.\d{1,5}.*/));
         });
 
-        it('hooks throw should not affect user flow or span creation', async () => {
-            const attributeNameFromHook = 'attribute.name.from.hook';
-            const hookAttributeValue = 'attribute value from hook';
+        describe('hooks', () => {
+            it('publish and consume hooks success', async () => {
+                const attributeNameFromHook = 'attribute.name.from.hook';
+                const hookAttributeValue = 'attribute value from hook';
+                const attributeNameFromEndHook = 'attribute.name.from.endhook';
+                const endHookAttributeValue = 'attribute value from end hook';
+                instrumentation.setConfig({
+                    publishHook: (span: Span, publishParams: PublishParams): void => {
+                        span.setAttribute(attributeNameFromHook, hookAttributeValue);
+                        expect(publishParams.exchange).toEqual('');
+                        expect(publishParams.routingKey).toEqual(queueName);
+                        expect(publishParams.content.toString()).toEqual(msgPayload);
+                    },
+                    consumeHook: (span: Span, msg: amqp.ConsumeMessage | null): void => {
+                        span.setAttribute(attributeNameFromHook, hookAttributeValue);
+                        expect(msg.content.toString()).toEqual(msgPayload);
+                    },
+                    consumeEndHook: (
+                        span: Span,
+                        msg: amqp.ConsumeMessage | null,
+                        rejected: boolean,
+                        endOperation: EndOperation
+                    ): void => {
+                        span.setAttribute(attributeNameFromEndHook, endHookAttributeValue);
+                        expect(endOperation).toEqual(EndOperation.AutoAck);
+                    },
+                });
+
+                channel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+                await asyncConsume(channel, queueName, [null], {
+                    noAck: true,
+                });
+                expect(getTestSpans().length).toBe(2);
+                expect(getTestSpans()[0].attributes[attributeNameFromHook]).toEqual(hookAttributeValue);
+                expect(getTestSpans()[1].attributes[attributeNameFromHook]).toEqual(hookAttributeValue);
+                expect(getTestSpans()[1].attributes[attributeNameFromEndHook]).toEqual(endHookAttributeValue);
+            });
+
+            it('hooks throw should not affect user flow or span creation', async () => {
+                const attributeNameFromHook = 'attribute.name.from.hook';
+                const hookAttributeValue = 'attribute value from hook';
+                instrumentation.setConfig({
+                    publishHook: (span: Span, publishParams: PublishParams): void => {
+                        span.setAttribute(attributeNameFromHook, hookAttributeValue);
+                        throw new Error('error from hook');
+                    },
+                    consumeHook: (span: Span, msg: amqp.ConsumeMessage | null): void => {
+                        span.setAttribute(attributeNameFromHook, hookAttributeValue);
+                        throw new Error('error from hook');
+                    },
+                });
+
+                channel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+                await asyncConsume(channel, queueName, [null], {
+                    noAck: true,
+                });
+                expect(getTestSpans().length).toBe(2);
+                getTestSpans().forEach((s) => expect(s.attributes[attributeNameFromHook]).toEqual(hookAttributeValue));
+            });
+        });
+    });
+
+    describe('confirm channel', () => {
+        let confirmChannel: amqp.ConfirmChannel;
+        beforeEach(async () => {
+            endHookSpy = sinon.spy();
             instrumentation.setConfig({
-                publishHook: (span: Span, publishParams: PublishParams): void => {
-                    span.setAttribute(attributeNameFromHook, hookAttributeValue);
-                    throw new Error('error from hook');
-                },
-                consumeHook: (span: Span, msg: amqp.ConsumeMessage | null): void => {
-                    span.setAttribute(attributeNameFromHook, hookAttributeValue);
-                    throw new Error('error from hook');
-                },
+                consumeEndHook: endHookSpy,
             });
 
-            channel.sendToQueue(queueName, Buffer.from(msgPayload));
+            confirmChannel = await conn.createConfirmChannel();
+            await confirmChannel.assertQueue(queueName, { durable: false });
+            await confirmChannel.purgeQueue(queueName);
+            // install an error handler, otherwise when we have tests that create error on the channel,
+            // it throws and crash process
+            confirmChannel.on('error', (err) => {});
+        });
+        afterEach(async () => {
+            if (!confirmChannel[CHANNEL_CLOSED_IN_TEST]) {
+                try {
+                    await new Promise<void>((resolve) => {
+                        confirmChannel.on('close', resolve);
+                        confirmChannel.close();
+                    });
+                } catch {}
+            }
+        });
 
-            await asyncConsume(channel, queueName, [null], {
-                noAck: true,
+        it('simple publish and consume from queue', async () => {
+            const hadSpaceInBuffer = confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload));
+            expect(hadSpaceInBuffer).toBeTruthy();
+
+            await asyncConsume(
+                confirmChannel,
+                queueName,
+                [(msg) => expect(msg.content.toString()).toEqual(msgPayload)],
+                {
+                    noAck: true,
+                }
+            );
+            const [publishSpan, consumeSpan] = getTestSpans();
+
+            // assert publish span
+            expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+            expect(publishSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('rabbitmq');
+            expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
+            expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toEqual(
+                MessagingDestinationKindValues.QUEUE
+            );
+            expect(publishSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(queueName);
+            expect(publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]).toEqual('AMQP');
+            expect(publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]).toEqual('0.9.1');
+            expect(publishSpan.attributes[SemanticAttributes.MESSAGING_URL]).toEqual(url);
+            expect(publishSpan.attributes[SemanticAttributes.NET_PEER_NAME]).toEqual(TEST_RABBITMQ_HOST);
+            expect(publishSpan.attributes[SemanticAttributes.NET_PEER_PORT]).toEqual(TEST_RABBITMQ_PORT);
+
+            // assert consume span
+            expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+            expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('rabbitmq');
+            expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
+            expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toEqual(
+                MessagingDestinationKindValues.QUEUE
+            );
+            expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(queueName);
+            expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]).toEqual('AMQP');
+            expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]).toEqual('0.9.1');
+            expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_URL]).toEqual(url);
+            expect(consumeSpan.attributes[SemanticAttributes.NET_PEER_NAME]).toEqual(TEST_RABBITMQ_HOST);
+            expect(consumeSpan.attributes[SemanticAttributes.NET_PEER_PORT]).toEqual(TEST_RABBITMQ_PORT);
+
+            // assert context propagation
+            expect(consumeSpan.spanContext().traceId).toEqual(publishSpan.spanContext().traceId);
+            expect(consumeSpan.parentSpanId).toEqual(publishSpan.spanContext().spanId);
+
+            expectConsumeEndSpyStatus([EndOperation.AutoAck]);
+        });
+
+        describe('ending consume spans', () => {
+            it('message acked sync', async () => {
+                confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+                await asyncConsume(confirmChannel, queueName, [(msg) => confirmChannel.ack(msg)]);
+                // assert consumed message span has ended
+                expect(getTestSpans().length).toBe(2);
+                expectConsumeEndSpyStatus([EndOperation.Ack]);
             });
+
+            it('message acked async', async () => {
+                confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+                // start async timer and ack the message after the callback returns
+                await new Promise<void>((resolve) => {
+                    asyncConsume(confirmChannel, queueName, [
+                        (msg) =>
+                            setTimeout(() => {
+                                confirmChannel.ack(msg);
+                                resolve();
+                            }, 1),
+                    ]);
+                });
+                // assert consumed message span has ended
+                expect(getTestSpans().length).toBe(2);
+                expectConsumeEndSpyStatus([EndOperation.Ack]);
+            });
+
+            it('message nack no requeue', async () => {
+                confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+                await asyncConsume(confirmChannel, queueName, [(msg) => confirmChannel.nack(msg, false, false)]);
+                await new Promise((resolve) => setTimeout(resolve, 20)); // just make sure we don't get it again
+                // assert consumed message span has ended
+                expect(getTestSpans().length).toBe(2);
+                const [_, consumerSpan] = getTestSpans();
+                expect(consumerSpan.status.code).toEqual(SpanStatusCode.ERROR);
+                expect(consumerSpan.status.message).toEqual('nack called on message without requeue');
+                expectConsumeEndSpyStatus([EndOperation.Nack]);
+            });
+
+            it('message nack requeue, then acked', async () => {
+                confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+                // @ts-ignore
+                await asyncConsume(confirmChannel, queueName, [
+                    (msg: amqp.Message) => confirmChannel.nack(msg, false, true),
+                    (msg: amqp.Message) => confirmChannel.ack(msg),
+                ]);
+                // assert we have the requeued message sent again
+                expect(getTestSpans().length).toBe(3);
+                const [_, rejectedConsumerSpan, successConsumerSpan] = getTestSpans();
+                expect(rejectedConsumerSpan.status.code).toEqual(SpanStatusCode.ERROR);
+                expect(rejectedConsumerSpan.status.message).toEqual('nack called on message with requeue');
+                expect(successConsumerSpan.status.code).toEqual(SpanStatusCode.OK);
+                expectConsumeEndSpyStatus([EndOperation.Nack, EndOperation.Ack]);
+            });
+
+            it('ack allUpTo 2 msgs sync', async () => {
+                lodash.times(3, () => confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload)));
+
+                // @ts-ignore
+                await asyncConsume(confirmChannel, queueName, [
+                    null,
+                    (msg) => confirmChannel.ack(msg, true),
+                    (msg) => confirmChannel.ack(msg),
+                ]);
+                // assert all 3 messages are acked, including the first one which is acked by allUpTo
+                expect(getTestSpans().length).toBe(6);
+                expectConsumeEndSpyStatus([EndOperation.Ack, EndOperation.Ack, EndOperation.Ack]);
+            });
+
+            it('nack allUpTo 2 msgs sync', async () => {
+                lodash.times(3, () => confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload)));
+
+                // @ts-ignore
+                await asyncConsume(confirmChannel, queueName, [
+                    null,
+                    (msg) => confirmChannel.nack(msg, true, false),
+                    (msg) => confirmChannel.nack(msg, false, false),
+                ]);
+                // assert all 3 messages are acked, including the first one which is acked by allUpTo
+                expect(getTestSpans().length).toBe(6);
+                lodash.range(3, 6).forEach((i) => {
+                    expect(getTestSpans()[i].status.code).toEqual(SpanStatusCode.ERROR);
+                    expect(getTestSpans()[i].status.message).toEqual('nack called on message without requeue');
+                });
+                expectConsumeEndSpyStatus([EndOperation.Nack, EndOperation.Nack, EndOperation.Nack]);
+            });
+
+            it('ack not in received order', async () => {
+                lodash.times(3, () => confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload)));
+
+                // @ts-ignore
+                const msgs = await asyncConsume(confirmChannel, queueName, [null, null, null]);
+                confirmChannel.ack(msgs[1]);
+                confirmChannel.ack(msgs[2]);
+                confirmChannel.ack(msgs[0]);
+                // assert all 3 span messages are ended
+                expect(getTestSpans().length).toBe(6);
+                expectConsumeEndSpyStatus([EndOperation.Ack, EndOperation.Ack, EndOperation.Ack]);
+            });
+
+            it('ackAll', async () => {
+                lodash.times(2, () => confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload)));
+
+                // @ts-ignore
+                await asyncConsume(confirmChannel, queueName, [null, () => confirmChannel.ackAll()]);
+                // assert all 2 span messages are ended by call to ackAll
+                expect(getTestSpans().length).toBe(4);
+                expectConsumeEndSpyStatus([EndOperation.AckAll, EndOperation.AckAll]);
+            });
+
+            it('nackAll', async () => {
+                lodash.times(2, () => confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload)));
+
+                // @ts-ignore
+                await asyncConsume(confirmChannel, queueName, [null, () => confirmChannel.nackAll(false)]);
+                // assert all 2 span messages are ended by calling nackAll
+                expect(getTestSpans().length).toBe(4);
+                lodash.range(2, 4).forEach((i) => {
+                    expect(getTestSpans()[i].status.code).toEqual(SpanStatusCode.ERROR);
+                    expect(getTestSpans()[i].status.message).toEqual('nackAll called on message without requeue');
+                });
+                expectConsumeEndSpyStatus([EndOperation.NackAll, EndOperation.NackAll]);
+            });
+
+            it('reject', async () => {
+                lodash.times(1, () => confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload)));
+
+                // @ts-ignore
+                await asyncConsume(confirmChannel, queueName, [(msg) => confirmChannel.reject(msg, false)]);
+                expect(getTestSpans().length).toBe(2);
+                expect(getTestSpans()[1].status.code).toEqual(SpanStatusCode.ERROR);
+                expect(getTestSpans()[1].status.message).toEqual('reject called on message without requeue');
+                expectConsumeEndSpyStatus([EndOperation.Reject]);
+            });
+
+            it('reject with requeue', async () => {
+                lodash.times(1, () => confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload)));
+
+                // @ts-ignore
+                await asyncConsume(confirmChannel, queueName, [
+                    (msg) => confirmChannel.reject(msg, true),
+                    (msg) => confirmChannel.reject(msg, false),
+                ]);
+                expect(getTestSpans().length).toBe(3);
+                expect(getTestSpans()[1].status.code).toEqual(SpanStatusCode.ERROR);
+                expect(getTestSpans()[1].status.message).toEqual('reject called on message with requeue');
+                expect(getTestSpans()[2].status.code).toEqual(SpanStatusCode.ERROR);
+                expect(getTestSpans()[2].status.message).toEqual('reject called on message without requeue');
+                expectConsumeEndSpyStatus([EndOperation.Reject, EndOperation.Reject]);
+            });
+
+            it('closing channel should end all open spans on it', async () => {
+                lodash.times(1, () => confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload)));
+
+                await new Promise<void>((resolve) =>
+                    asyncConsume(confirmChannel, queueName, [
+                        async (msg) => {
+                            await confirmChannel.close();
+                            resolve();
+                            confirmChannel[CHANNEL_CLOSED_IN_TEST] = true;
+                        },
+                    ])
+                );
+
+                expect(getTestSpans().length).toBe(2);
+                expect(getTestSpans()[1].status.code).toEqual(SpanStatusCode.ERROR);
+                expect(getTestSpans()[1].status.message).toEqual('channel closed');
+                expectConsumeEndSpyStatus([EndOperation.ChannelClosed]);
+            });
+
+            it('error on channel should end all open spans on it', (done) => {
+                lodash.times(2, () => confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload)));
+
+                confirmChannel.on('close', () => {
+                    expect(getTestSpans().length).toBe(4);
+                    // second consume ended with valid ack, previous message not acked when channel is errored.
+                    // since we first ack the second message, it appear first in the finished spans array
+                    expect(getTestSpans()[2].status.code).toEqual(SpanStatusCode.OK);
+                    expect(getTestSpans()[3].status.code).toEqual(SpanStatusCode.ERROR);
+                    expect(getTestSpans()[3].status.message).toEqual('channel error');
+                    expectConsumeEndSpyStatus([EndOperation.Ack, EndOperation.ChannelError]);
+                    done();
+                });
+                asyncConsume(confirmChannel, queueName, [
+                    null,
+                    (msg) => {
+                        try {
+                            confirmChannel.ack(msg);
+                            confirmChannel[CHANNEL_CLOSED_IN_TEST] = true;
+                            // ack the same msg again, this is not valid and should close the channel
+                            confirmChannel.ack(msg);
+                        } catch {}
+                    },
+                ]);
+            });
+
+            it('not acking the message trigger timeout', async () => {
+                instrumentation.setConfig({
+                    consumeEndHook: endHookSpy,
+                    consumeTimeoutMs: 1,
+                });
+
+                lodash.times(1, () => confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload)));
+
+                await asyncConsume(confirmChannel, queueName, [null]);
+
+                // we have timeout of 1 ms, so we wait more than that and check span indeed ended
+                await new Promise((resolve) => setTimeout(resolve, 10));
+
+                expect(getTestSpans().length).toBe(2);
+                expectConsumeEndSpyStatus([EndOperation.InstrumentationTimeout]);
+            });
+        });
+
+        describe('routing and exchange', () => {
+            it('topic exchange', async () => {
+                const exchangeName = 'topic exchange';
+                const routingKey = 'topic.name.from.unittest';
+                await confirmChannel.assertExchange(exchangeName, 'topic', { durable: false });
+
+                const { queue: queueName } = await confirmChannel.assertQueue('', { durable: false });
+                await confirmChannel.bindQueue(queueName, exchangeName, '#');
+
+                confirmChannel.publish(exchangeName, routingKey, Buffer.from(msgPayload));
+
+                await asyncConsume(confirmChannel, queueName, [null], {
+                    noAck: true,
+                });
+
+                const [publishSpan, consumeSpan] = getTestSpans();
+
+                // assert publish span
+                expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('rabbitmq');
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(exchangeName);
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toEqual(
+                    MessagingDestinationKindValues.QUEUE
+                );
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(routingKey);
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]).toEqual('AMQP');
+                expect(publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]).toEqual('0.9.1');
+
+                // assert consume span
+                expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual('rabbitmq');
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(exchangeName);
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toEqual(
+                    MessagingDestinationKindValues.QUEUE
+                );
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]).toEqual(routingKey);
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]).toEqual('AMQP');
+                expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]).toEqual('0.9.1');
+
+                // assert context propagation
+                expect(consumeSpan.spanContext().traceId).toEqual(publishSpan.spanContext().traceId);
+                expect(consumeSpan.parentSpanId).toEqual(publishSpan.spanContext().spanId);
+            });
+        });
+
+        it('moduleVersionAttributeName works with publish and consume', async () => {
+            const VERSION_ATTR = 'module.version';
+            instrumentation.setConfig({
+                moduleVersionAttributeName: VERSION_ATTR,
+            });
+
+            confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+            await asyncConsume(
+                confirmChannel,
+                queueName,
+                [(msg) => expect(msg.content.toString()).toEqual(msgPayload)],
+                {
+                    noAck: true,
+                }
+            );
             expect(getTestSpans().length).toBe(2);
-            getTestSpans().forEach((s) => expect(s.attributes[attributeNameFromHook]).toEqual(hookAttributeValue));
+            getTestSpans().forEach((s) => expect(s.attributes[VERSION_ATTR]).toMatch(/\d{1,4}\.\d{1,4}\.\d{1,5}.*/));
+        });
+
+        describe('hooks', () => {
+            it('publish and consume hooks success', async () => {
+                const attributeNameFromHook = 'attribute.name.from.hook';
+                const hookAttributeValue = 'attribute value from hook';
+                const attributeNameFromConfirmEndHook = 'attribute.name.from.confirm.endhook';
+                const confirmEndHookAttributeValue = 'attribute value from confirm end hook';
+                const attributeNameFromConsumeEndHook = 'attribute.name.from.consume.endhook';
+                const consumeEndHookAttributeValue = 'attribute value from consume end hook';
+                instrumentation.setConfig({
+                    publishConfirmHook: (span: Span, publishParams: PublishParams): void => {
+                        span.setAttribute(attributeNameFromHook, hookAttributeValue);
+                        expect(publishParams.exchange).toEqual('');
+                        expect(publishParams.routingKey).toEqual(queueName);
+                        expect(publishParams.content.toString()).toEqual(msgPayload);
+                    },
+                    publishConfirmEndHook: (span, publishParams) => {
+                        span.setAttribute(attributeNameFromConfirmEndHook, confirmEndHookAttributeValue);
+                        expect(publishParams.exchange).toEqual('');
+                        expect(publishParams.routingKey).toEqual(queueName);
+                        expect(publishParams.content.toString()).toEqual(msgPayload);
+                    },
+                    consumeHook: (span: Span, msg: amqp.ConsumeMessage | null): void => {
+                        span.setAttribute(attributeNameFromHook, hookAttributeValue);
+                        expect(msg.content.toString()).toEqual(msgPayload);
+                    },
+                    consumeEndHook: (
+                        span: Span,
+                        msg: amqp.ConsumeMessage | null,
+                        rejected: boolean,
+                        endOperation: EndOperation
+                    ): void => {
+                        span.setAttribute(attributeNameFromConsumeEndHook, consumeEndHookAttributeValue);
+                        expect(endOperation).toEqual(EndOperation.AutoAck);
+                    },
+                });
+
+                confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+                await asyncConsume(confirmChannel, queueName, [null], {
+                    noAck: true,
+                });
+                expect(getTestSpans().length).toBe(2);
+                expect(getTestSpans()[0].attributes[attributeNameFromHook]).toEqual(hookAttributeValue);
+                expect(getTestSpans()[0].attributes[attributeNameFromConfirmEndHook]).toEqual(
+                    confirmEndHookAttributeValue
+                );
+                expect(getTestSpans()[1].attributes[attributeNameFromHook]).toEqual(hookAttributeValue);
+                expect(getTestSpans()[1].attributes[attributeNameFromConsumeEndHook]).toEqual(
+                    consumeEndHookAttributeValue
+                );
+            });
+
+            it('hooks throw should not affect user flow or span creation', async () => {
+                const attributeNameFromHook = 'attribute.name.from.hook';
+                const hookAttributeValue = 'attribute value from hook';
+                instrumentation.setConfig({
+                    publishConfirmHook: (span: Span, publishParams: PublishParams): void => {
+                        span.setAttribute(attributeNameFromHook, hookAttributeValue);
+                        throw new Error('error from hook');
+                    },
+                    publishConfirmEndHook: (span: Span, publishParams: PublishParams): void => {
+                        span.setAttribute(attributeNameFromHook, hookAttributeValue);
+                        throw new Error('error from hook');
+                    },
+                    consumeHook: (span: Span, msg: amqp.ConsumeMessage | null): void => {
+                        span.setAttribute(attributeNameFromHook, hookAttributeValue);
+                        throw new Error('error from hook');
+                    },
+                });
+
+                confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+                await asyncConsume(confirmChannel, queueName, [null], {
+                    noAck: true,
+                });
+                expect(getTestSpans().length).toBe(2);
+                getTestSpans().forEach((s) => expect(s.attributes[attributeNameFromHook]).toEqual(hookAttributeValue));
+            });
         });
     });
 });

--- a/packages/instrumentation-amqplib/test/config.ts
+++ b/packages/instrumentation-amqplib/test/config.ts
@@ -2,4 +2,4 @@
 // 1. 'test:docker:run' script in package.json
 // 2. services in github actions workflow
 export const TEST_RABBITMQ_HOST = 'localhost';
-export const TEST_RABBITMQ_PORT = 22221;
+export const TEST_RABBITMQ_PORT = 5672; //22221;

--- a/packages/instrumentation-amqplib/test/config.ts
+++ b/packages/instrumentation-amqplib/test/config.ts
@@ -2,4 +2,4 @@
 // 1. 'test:docker:run' script in package.json
 // 2. services in github actions workflow
 export const TEST_RABBITMQ_HOST = 'localhost';
-export const TEST_RABBITMQ_PORT = 5672; //22221;
+export const TEST_RABBITMQ_PORT = 22221;

--- a/packages/instrumentation-amqplib/test/utils.ts
+++ b/packages/instrumentation-amqplib/test/utils.ts
@@ -5,10 +5,18 @@ import expect from 'expect';
 export const asyncConfirmSend = (
     confirmChannel: amqp.ConfirmChannel | amqpCallback.ConfirmChannel,
     queueName: string,
-    msgPayload: string
+    msgPayload: string,
+    callback?: () => void
 ): Promise<void> => {
-    return new Promise<void>((resolve) => {
-        const hadSpaceInBuffer = confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload), {}, (err) => resolve());
+    return new Promise<void>((resolve, reject) => {
+        const hadSpaceInBuffer = confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload), {}, (err) => {
+            try {
+                callback?.();
+                resolve();
+            } catch (e) {
+                reject(e);
+            }
+        });
         expect(hadSpaceInBuffer).toBeTruthy();
     });
 };
@@ -17,12 +25,18 @@ export const asyncConfirmPublish = (
     confirmChannel: amqp.ConfirmChannel | amqpCallback.ConfirmChannel,
     exchange: string,
     routingKey: string,
-    msgPayload: string
+    msgPayload: string,
+    callback?: () => void
 ): Promise<void> => {
-    return new Promise<void>((resolve) => {
-        const hadSpaceInBuffer = confirmChannel.publish(exchange, routingKey, Buffer.from(msgPayload), {}, (err) =>
-            resolve()
-        );
+    return new Promise<void>((resolve, reject) => {
+        const hadSpaceInBuffer = confirmChannel.publish(exchange, routingKey, Buffer.from(msgPayload), {}, (err) => {
+            try {
+                callback?.();
+                resolve();
+            } catch (e) {
+                reject(e);
+            }
+        });
         expect(hadSpaceInBuffer).toBeTruthy();
     });
 };

--- a/packages/instrumentation-amqplib/test/utils.ts
+++ b/packages/instrumentation-amqplib/test/utils.ts
@@ -1,8 +1,34 @@
 import type amqp from 'amqplib';
 import type amqpCallback from 'amqplib/callback_api';
+import expect from 'expect';
+
+export const asyncConfirmSend = (
+    confirmChannel: amqp.ConfirmChannel | amqpCallback.ConfirmChannel,
+    queueName: string,
+    msgPayload: string
+): Promise<void> => {
+    return new Promise<void>((resolve) => {
+        const hadSpaceInBuffer = confirmChannel.sendToQueue(queueName, Buffer.from(msgPayload), {}, (err) => resolve());
+        expect(hadSpaceInBuffer).toBeTruthy();
+    });
+};
+
+export const asyncConfirmPublish = (
+    confirmChannel: amqp.ConfirmChannel | amqpCallback.ConfirmChannel,
+    exchange: string,
+    routingKey: string,
+    msgPayload: string
+): Promise<void> => {
+    return new Promise<void>((resolve) => {
+        const hadSpaceInBuffer = confirmChannel.publish(exchange, routingKey, Buffer.from(msgPayload), {}, (err) =>
+            resolve()
+        );
+        expect(hadSpaceInBuffer).toBeTruthy();
+    });
+};
 
 export const asyncConsume = (
-    channel: amqp.Channel | amqpCallback.Channel,
+    channel: amqp.Channel | amqpCallback.Channel | amqp.ConfirmChannel | amqpCallback.ConfirmChannel,
     queueName: string,
     callback: ((msg: amqp.Message) => unknown)[],
     options?: amqp.Options.Consume


### PR DESCRIPTION
Hi. This PR resolves https://github.com/aspecto-io/opentelemetry-ext-js/issues/84 with adding instrumentation to publish via ConfirmChannel of amqplib.

### Implementation:

 I am adding a new patch for confirm channel publish method which creates span in a similar way to normal channel publish. Span ends when the broker confirms the sent message (either ack or nack). If callback won't be fired (due to connection error or different protocol issue) the span will never end and there is no timeout implemented. 

It reassembles (afaik) a similar approach to unconfirmed messages callbacks of amqlib which shift out the whole callback array on channel error. Instrumentation is not storing the reference to these anywhere so it should be sufficient for eventual GC memory reclaim during channel close. 

Additionally, there are two new hooks for confirm channel publish and confirmation which work analogically to existing hooks.

For existing normal channel publish implementation stays pretty much the same with a difference that when the requesting channel is of confirm type it will skip the logic altogether (instrumentation was already done in cc.publish patched method)

### Minor changes: 
- I am adding `SemanticAttributes.MESSAGING_MESSAGE_ID` span attribute based on `options?.messageId`/`msg?.properties.messageId` in `publish`/`consume` spans as I feel they match exactly (might be overridden with hooks in case of user-specific values which resides elsewhere)
- I am adding `SemanticAttributes.MESSAGING_CONVERSATION_ID` span attributes based on `options?.correlationId`/`msg?.properties.correlationId` in `publish`/`consume` spans as I feel they match exactly (might be overridden with hooks in case of user-specific values which resides elsewhere)
- I am changing from `SemanticAttributes.MESSAGING_DESTINATION_KIND` attribute value `TOPIC` to `QUEUE` as in my opinion we don't have enough information to make a distinction if message arrives at `TOPIC` exchange, but in fact, will always arrive at some real `QUEUE` (if can be routed). I feel like this is more suited for RabbitMQ and `TOPIC` would always work in the case of Kafka.   
- I am removing `SpanStatusCode.ERROR` when the channel publish method returns `false` as it is no indication of publishing failure, only about stream reaching highWaterMark (reference: https://github.com/squaremo/amqp.node/issues/636)
- I am setting `SpanStatusCode.OK` in a place where we end spans successfully instead of the default (`SpanStatusCode.UNSET`)


### Tests:
Well, I didn't find any special tests for this case apart from that I would like to test confirm channel against the same scenarios as in the existing suite. So I cloned the existing tests under another describe (`confirm channel`) and put the existing tests into their own describe block (`channel`).

Additionally because now send span is not instant we can't make guarantees about its position in `finishedSpans` before consume span which is handy in case of normal channels tests. 

Because of that, I abstracted the send logic to awaited promise method which sends the msg and resolves only after the confirmation. This lets us preserve the same order as before (though locally the outcome was the same with or without await).

Of course, confirmation can be nack'ed but it is done only in case of internal erlang process failure inside the broker so it isn't something we can simulate. Additionally, it might not arrive when the connection breaks. Tests don't last more than few seconds after establishing a connection so it shouldn't be a problem for the test case. In real life scenario, we can and should expect that publish span of confirm channel might end after the start of consume span or that consume span has a chance to be orphaned. 

Thanks for the feedback!





