### PR TITLE
fix(instrumentation-amqplib): consumer cancel notification throws excption

### DIFF
--- a/packages/instrumentation-amqplib/src/amqplib.ts
+++ b/packages/instrumentation-amqplib/src/amqplib.ts
@@ -256,9 +256,16 @@ export class AmqplibInstrumentation extends InstrumentationBase<typeof amqp> {
             }
 
             const patchedOnMessage = function (msg: amqp.ConsumeMessage | null) {
-                const headers = msg.properties.headers;
+                // msg is expected to be null for signaling consumer cancel notification
+                // https://www.rabbitmq.com/consumer-cancel.html
+                // in this case, we do not start a span, as this is not a real message.
+                if (!msg) {
+                    return onMessage.call(this, msg);
+                }
+
+                const headers = msg.properties.headers ?? {};
                 const parentContext = propagation.extract(context.active(), headers);
-                const exchange = msg?.fields?.exchange;
+                const exchange = msg.fields?.exchange;
                 const span = self.tracer.startSpan(
                     `${queue} process`,
                     {
@@ -267,7 +274,7 @@ export class AmqplibInstrumentation extends InstrumentationBase<typeof amqp> {
                             ...channel?.connection?.[CONNECTION_ATTRIBUTES],
                             [SemanticAttributes.MESSAGING_DESTINATION]: exchange,
                             [SemanticAttributes.MESSAGING_DESTINATION_KIND]: MessagingDestinationKindValues.TOPIC,
-                            [SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]: msg?.fields?.routingKey,
+                            [SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]: msg.fields?.routingKey,
                             [SemanticAttributes.MESSAGING_OPERATION]: MessagingOperationValues.PROCESS,
                         },
                     },
@@ -403,12 +410,7 @@ export class AmqplibInstrumentation extends InstrumentationBase<typeof amqp> {
         });
     }
 
-    private callConsumeEndHook(
-        span: Span,
-        msg: amqp.ConsumeMessage | null,
-        rejected: boolean,
-        endOperation: EndOperation
-    ) {
+    private callConsumeEndHook(span: Span, msg: amqp.ConsumeMessage, rejected: boolean, endOperation: EndOperation) {
         if (!this._config.consumeEndHook) return;
 
         safeExecuteInTheMiddle(

--- a/packages/instrumentation-amqplib/src/types.ts
+++ b/packages/instrumentation-amqplib/src/types.ts
@@ -14,7 +14,7 @@ export interface AmqplibPublishCustomAttributeFunction {
 }
 
 export interface AmqplibConsumerCustomAttributeFunction {
-    (span: Span, msg: amqp.ConsumeMessage | null): void;
+    (span: Span, msg: amqp.ConsumeMessage): void;
 }
 
 export enum EndOperation {
@@ -30,7 +30,7 @@ export enum EndOperation {
 }
 
 export interface AmqplibConsumerEndCustomAttributeFunction {
-    (span: Span, msg: amqp.ConsumeMessage | null, rejected: boolean, endOperation: EndOperation): void;
+    (span: Span, msg: amqp.ConsumeMessage, rejected: boolean, endOperation: EndOperation): void;
 }
 
 export interface AmqplibInstrumentationConfig extends InstrumentationConfig {

--- a/packages/instrumentation-amqplib/test/amqplib-promise.spec.ts
+++ b/packages/instrumentation-amqplib/test/amqplib-promise.spec.ts
@@ -7,7 +7,7 @@ import { getTestSpans, registerInstrumentation } from '../../instrumentation-tes
 
 const instrumentation = registerInstrumentation(new AmqplibInstrumentation());
 
-import amqp from 'amqplib';
+import amqp, { ConsumeMessage } from 'amqplib';
 import { MessagingDestinationKindValues, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { Span, SpanKind, SpanStatusCode } from '@opentelemetry/api';
 import { asyncConsume } from './utils';
@@ -456,6 +456,17 @@ describe('amqplib instrumentation promise model', function () {
             });
             expect(getTestSpans().length).toBe(2);
             getTestSpans().forEach((s) => expect(s.attributes[attributeNameFromHook]).toEqual(hookAttributeValue));
+        });
+    });
+
+    describe('delete queue', () => {
+        it('consumer receives null msg when a queue is deleted in broker', async () => {
+            const queueNameForDeletion = 'queue-to-be-deleted';
+            await channel.assertQueue(queueNameForDeletion, { durable: false });
+            await channel.purgeQueue(queueNameForDeletion);
+
+            await channel.consume(queueNameForDeletion, (msg: ConsumeMessage | null) => {}, { noAck: true });
+            await channel.deleteQueue(queueNameForDeletion);
         });
     });
 });


### PR DESCRIPTION
Fixes #175 

This PR ignores falsely `msg`s, so they are not instrumented or traced, as they do not fit the current instrumentation specification.

In the future, we might want to add specific instrumentation for these messages with custom attributes and handling