### PR TITLE
feat: sequelize config queryHook

### DIFF
--- a/packages/instrumentation-sequelize/README.md
+++ b/packages/instrumentation-sequelize/README.md
@@ -1,7 +1,7 @@
 # OpenTelemetry Sequelize Instrumentation for Node.js
 [![NPM version](https://img.shields.io/npm/v/opentelemetry-instrumentation-sequelize.svg)](https://www.npmjs.com/package/opentelemetry-instrumentation-sequelize)
 
-This module provides automatic instrumentation for [`Sequelize`](https://sequelize.org/).  
+This module provides automatic instrumentation for [`Sequelize`](https://sequelize.org/).
 > _Tested and worked on versions v4, v5 and v6 of Sequelize._
 
 ## Installation
@@ -41,6 +41,7 @@ Sequelize instrumentation has few options available to choose from. You can set 
 
 | Options        | Type                                   | Description                                                                                     |
 | -------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `queryHook` | `SequelizeQueryHook` | Hook called before query is run, which allows to add custom attributes to span.      |
 | `responseHook` | `SequelizeResponseCustomAttributesFunction` | Hook called before response is returned, which allows to add custom attributes to span.      |
 | `ignoreOrphanedSpans` | `boolean` | Set to true if you only want to trace operation which has parent spans |
 | `moduleVersionAttributeName` | `string` | If passed, a span attribute will be added to all spans with key of the provided `moduleVersionAttributeName` and value of the patched module version |

--- a/packages/instrumentation-sequelize/src/sequelize.ts
+++ b/packages/instrumentation-sequelize/src/sequelize.ts
@@ -142,6 +142,16 @@ export class SequelizeInstrumentation extends InstrumentationBase<typeof sequeli
 
             const activeContextWithSpan = trace.setSpan(context.active(), newSpan);
 
+            if (self._config?.queryHook) {
+                safeExecuteInTheMiddle(
+                    () => self._config.queryHook(newSpan, { sql, option }),
+                    (e: Error) => {
+                        if (e) diag.error('sequelize instrumentation: queryHook error', e);
+                    },
+                    true
+                );
+            }
+
             return context
                 .with(
                     self._config.suppressInternalInstrumentation

--- a/packages/instrumentation-sequelize/src/types.ts
+++ b/packages/instrumentation-sequelize/src/types.ts
@@ -1,11 +1,12 @@
 import { Span } from '@opentelemetry/api';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { Sequelize } from 'sequelize';
 
 export interface SequelizeQueryHookParams {
   /** The type of sql parameter depends on the database dialect. */
-  sql: any,
+  sql: Parameters<Sequelize['query']>[0];
   /** The type of option parameter depends on the database dialect. */
-  option: any,
+  option: Parameters<Sequelize['query']>[1];
 };
 
 export type SequelizeQueryHook = (span: Span, params: SequelizeQueryHookParams) => void;

--- a/packages/instrumentation-sequelize/src/types.ts
+++ b/packages/instrumentation-sequelize/src/types.ts
@@ -1,9 +1,20 @@
 import { Span } from '@opentelemetry/api';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 
+export interface SequelizeQueryHookParams {
+  /** The type of sql parameter depends on the database dialect. */
+  sql: any,
+  /** The type of option parameter depends on the database dialect. */
+  option: any,
+};
+
+export type SequelizeQueryHook = (span: Span, params: SequelizeQueryHookParams) => void;
+
 export type SequelizeResponseCustomAttributesFunction = (span: Span, response: any) => void;
 
 export interface SequelizeInstrumentationConfig extends InstrumentationConfig {
+    /** hook for adding custom attributes using the query */
+    queryHook?: SequelizeQueryHook;
     /** hook for adding custom attributes using the response payload */
     responseHook?: SequelizeResponseCustomAttributesFunction;
     /** Set to true if you only want to trace operation which has parent spans */

--- a/packages/instrumentation-sequelize/src/types.ts
+++ b/packages/instrumentation-sequelize/src/types.ts
@@ -3,11 +3,11 @@ import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import { Sequelize } from 'sequelize';
 
 export interface SequelizeQueryHookParams {
-  /** The type of sql parameter depends on the database dialect. */
-  sql: Parameters<Sequelize['query']>[0];
-  /** The type of option parameter depends on the database dialect. */
-  option: Parameters<Sequelize['query']>[1];
-};
+    /** The type of sql parameter depends on the database dialect. */
+    sql: Parameters<Sequelize['query']>[0];
+    /** The type of option parameter depends on the database dialect. */
+    option: Parameters<Sequelize['query']>[1];
+}
 
 export type SequelizeQueryHook = (span: Span, params: SequelizeQueryHookParams) => void;
 

--- a/packages/instrumentation-sequelize/src/types.ts
+++ b/packages/instrumentation-sequelize/src/types.ts
@@ -1,6 +1,6 @@
 import { Span } from '@opentelemetry/api';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
-import { Sequelize } from 'sequelize';
+import type { Sequelize } from 'sequelize';
 
 export interface SequelizeQueryHookParams {
     /** The type of sql parameter depends on the database dialect. */

--- a/packages/instrumentation-sequelize/test/sequelize.spec.ts
+++ b/packages/instrumentation-sequelize/test/sequelize.spec.ts
@@ -303,7 +303,7 @@ describe('instrumentation-sequelize', () => {
                     return new Promise((resolve) => resolve(response));
                 };
                 instrumentation.setConfig({
-                    queryHook: (span: Span, {sql, option}: {sql: any, option: any}) => {
+                    queryHook: (span: Span, { sql, option }: { sql: any; option: any }) => {
                         span.setAttribute('test-sql', 'any');
                         span.setAttribute('test-option', 'any');
                     },


### PR DESCRIPTION
Adds a new config `queryHook(span, { sql, option })` so that a span can be augmented with query details. The hook is run before the query is run.

Fixes #184