### PR TITLE
fix: instrumentation-aws-sdk typescript error

### DIFF
--- a/packages/instrumentation-aws-sdk/src/types.ts
+++ b/packages/instrumentation-aws-sdk/src/types.ts
@@ -1,6 +1,6 @@
 import { Span } from '@opentelemetry/api';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
-import type AWS from 'aws-sdk';
+import type { SQS } from 'aws-sdk';
 
 /**
  * These are normalized request and response, which are used by both sdk v2 and v3.
@@ -32,7 +32,7 @@ export interface AwsSdkResponseCustomAttributeFunction {
 }
 
 export interface AwsSdkSqsProcessCustomAttributeFunction {
-    (span: Span, message: AWS.SQS.Message): void;
+    (span: Span, message: SQS.Message): void;
 }
 
 export interface AwsSdkInstrumentationConfig extends InstrumentationConfig {

--- a/packages/instrumentation-socket.io/README.md
+++ b/packages/instrumentation-socket.io/README.md
@@ -18,7 +18,7 @@ const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 const { SocketIoInstrumentation } = require('opentelemetry-instrumentation-socket.io);
 
 registerInstrumentations({
-  traceProvider,
+  tracerProvider,
   instrumentations: [
     new SocketIoInstrumentation({
       // see under for available configuration

--- a/packages/instrumentation-socket.io/README.md
+++ b/packages/instrumentation-socket.io/README.md
@@ -18,7 +18,7 @@ const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 const { SocketIoInstrumentation } = require('opentelemetry-instrumentation-socket.io);
 
 registerInstrumentations({
-  tracerProvider,
+  traceProvider,
   instrumentations: [
     new SocketIoInstrumentation({
       // see under for available configuration


### PR DESCRIPTION
fix the following error:

`opentelemetry-instrumentation-aws-sdk/dist/src/types.d.ts:3:13 - error TS1192: Module '".../node_modules/aws-sdk/index"' has no default export.

3 import type AWS from 'aws-sdk';
              ~~~


Found 1 error.
`