### PR TITLE
fix(express): return original response

### DIFF
--- a/packages/instrumentation-express/src/express.ts
+++ b/packages/instrumentation-express/src/express.ts
@@ -234,7 +234,7 @@ export class ExpressInstrumentation extends InstrumentationBase<typeof express> 
                     }
                 }
 
-                oldResEnd.apply(res, arguments);
+                const origRes = oldResEnd.apply(res, arguments);
 
                 span.setAttributes(routeAttributes);
                 if (plugin._config.includeHttpAttributes) {
@@ -248,6 +248,8 @@ export class ExpressInstrumentation extends InstrumentationBase<typeof express> 
                 }
 
                 span.end();
+
+                return origRes;
             };
 
             next();


### PR DESCRIPTION
Should fix express error: 
```
src/express.ts(226,13): error TS2322: Type '() => void' is not assignable to type '{ (cb?: () => void): Response<any>; (chunk: any, cb?: () => void): Response<any>; (chunk: any, encoding: BufferEncoding, cb?: () => void): Response<any>; }'.
  Type 'void' is not assignable to type 'Response<any>'.
```