### PR TITLE
test(typeorm): increase test timeout

### DIFF
--- a/packages/instrumentation-typeorm/test/config.spec.ts
+++ b/packages/instrumentation-typeorm/test/config.spec.ts
@@ -11,7 +11,7 @@ import { defaultOptions, User } from './utils';
 import { SpanStatusCode } from '@opentelemetry/api';
 
 describe('TypeormInstrumentationConfig', () => {
-    it('responseHook', async function() {
+    it('responseHook', async function () {
         this.timeout(3_000);
         instrumentation.disable();
         const config: TypeormInstrumentationConfig = {

--- a/packages/instrumentation-typeorm/test/config.spec.ts
+++ b/packages/instrumentation-typeorm/test/config.spec.ts
@@ -11,7 +11,8 @@ import { defaultOptions, User } from './utils';
 import { SpanStatusCode } from '@opentelemetry/api';
 
 describe('TypeormInstrumentationConfig', () => {
-    it('responseHook', async () => {
+    it('responseHook', async function() {
+        this.timeout(3_000);
         instrumentation.disable();
         const config: TypeormInstrumentationConfig = {
             responseHook: (span: Span, response: any) => {


### PR DESCRIPTION
TypeORM tests fail sometimes because of timeout error. It happen for test `TypeormInstrumentationConfig` -> `responseHook`. 

When the test pass successfully, it take more than 1.2 seconds.
In this PR I increased the timeout to 3 seconds.
