### PR TITLE
test(kafkajs): add missing heartbeat function

### DIFF
--- a/packages/instrumentation-kafkajs/test/kafkajs.spec.ts
+++ b/packages/instrumentation-kafkajs/test/kafkajs.spec.ts
@@ -381,6 +381,7 @@ describe('instrumentation-kafkajs', () => {
                 topic: 'topic-name-1',
                 partition: 0,
                 message: createKafkaMessage('123'),
+                heartbeat: () => { return Promise.resolve() },
             };
         };
 
@@ -698,6 +699,7 @@ describe('instrumentation-kafkajs', () => {
 
             expect(messagesSent.length).toBe(1);
             const consumerPayload: EachMessagePayload = {
+                heartbeat: () => { return Promise.resolve() },
                 topic: 'topic-name-1',
                 partition: 0,
                 message: {

--- a/packages/instrumentation-kafkajs/test/kafkajs.spec.ts
+++ b/packages/instrumentation-kafkajs/test/kafkajs.spec.ts
@@ -381,7 +381,9 @@ describe('instrumentation-kafkajs', () => {
                 topic: 'topic-name-1',
                 partition: 0,
                 message: createKafkaMessage('123'),
-                heartbeat: () => { return Promise.resolve() },
+                heartbeat: () => {
+                    return Promise.resolve();
+                },
             };
         };
 
@@ -699,7 +701,9 @@ describe('instrumentation-kafkajs', () => {
 
             expect(messagesSent.length).toBe(1);
             const consumerPayload: EachMessagePayload = {
-                heartbeat: () => { return Promise.resolve() },
+                heartbeat: () => {
+                    return Promise.resolve();
+                },
                 topic: 'topic-name-1',
                 partition: 0,
                 message: {


### PR DESCRIPTION
`heartbeat` function was added in the last `kafkajs` version `1.16.0`.

This PR should fix failing daily tests