### PR TITLE
fix: re-order span.end() so that applyResponseHook affects emitted span

### DIFF
--- a/packages/instrumentation-mongoose/src/utils.ts
+++ b/packages/instrumentation-mongoose/src/utils.ts
@@ -80,8 +80,8 @@ export function handlePromiseResponse(
     responseHook?: MongooseResponseCustomAttributesFunction
 ): any {
     if (!(execResponse instanceof Promise)) {
-        span.end();
         applyResponseHook(span, execResponse, responseHook);
+        span.end();
         return execResponse;
     }
 


### PR DESCRIPTION
Fix for: https://github.com/aspecto-io/opentelemetry-ext-js/issues/218

Re-orders the `span.end()` call so that it is called after the span is modified by the `applyResponseHook()` function.