### PR TITLE
fix(kafkajs): Support prerelease versions

### DIFF
--- a/packages/instrumentation-kafkajs/src/kafkajs.ts
+++ b/packages/instrumentation-kafkajs/src/kafkajs.ts
@@ -53,12 +53,10 @@ export class KafkaJsInstrumentation extends InstrumentationBase<typeof kafkaJs> 
     }
 
     protected init(): InstrumentationModuleDefinition<typeof kafkaJs> {
-        const module = new InstrumentationNodeModuleDefinition<typeof kafkaJs>(
-            KafkaJsInstrumentation.component,
-            ['*'],
-            this.patch.bind(this),
-            this.unpatch.bind(this)
-        );
+        const module: InstrumentationModuleDefinition<typeof kafkaJs> = new InstrumentationNodeModuleDefinition<
+            typeof kafkaJs
+        >(KafkaJsInstrumentation.component, ['*'], this.patch.bind(this), this.unpatch.bind(this));
+        module.includePrerelease = true;
         return module;
     }
 


### PR DESCRIPTION
Utilises mechanism added here https://github.com/open-telemetry/opentelemetry-js/issues/2294
to support pre-release kafkaJS versions

closes #222