### PR TITLE
chore: upgrade opentelemetry instrumentation library for kafka

### DIFF
--- a/packages/instrumentation-kafkajs/package.json
+++ b/packages/instrumentation-kafkajs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "opentelemetry-instrumentation-kafkajs",
-    "version": "0.28.0",
+    "version": "0.29.0",
     "description": "open telemetry instrumentation for the `kafkajs` kafka client",
     "keywords": [
         "kafka",
@@ -38,13 +38,13 @@
         "@opentelemetry/api": "^1.0.0"
     },
     "dependencies": {
-        "@opentelemetry/instrumentation": "^0.28.0",
+        "@opentelemetry/instrumentation": "^0.29.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/contrib-test-utils": "^0.30.0",
-        "@opentelemetry/sdk-trace-base": "1.2.0",
+        "@opentelemetry/contrib-test-utils": "^0.31.0",
+        "@opentelemetry/sdk-trace-base": "^1.3.1",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "kafkajs": "^1.12.0",


### PR DESCRIPTION
Updates the dependencies so the library is usable with the newest SDK