### PR TITLE
feat: support core experimental version 0.32.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The instrumentations in this repo are:
 
 | Instrumentations Version | OpenTelemetry Core | OpenTelemetry Experimental | 
 | --- | --- | --- |
-| 0.30.x | ^1.0.0 | ^0.32.0 |
+| 0.32.x | ^1.0.0 | ^0.32.0 |
 | 0.29.x | ^1.0.0 | ^0.29.0 |
 | 0.28.x | ^1.0.0 | ^0.28.0 |
 | 0.27.x | ^1.0.1 | ^0.27.0 |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The instrumentations in this repo are:
 - strictly complies with [open telemetry semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions)
 - up to date with latest SDK version
 
-**Compatible with [SDK stable ^1.0.0](https://github.com/open-telemetry/opentelemetry-js/tree/stable/v1.0.0) and [SDK experimental ^0.29.0](https://github.com/open-telemetry/opentelemetry-js/tree/v0.29.0/experimental/packages)**
+**Compatible with [SDK stable ^1.0.0](https://github.com/open-telemetry/opentelemetry-js/tree/stable/v1.0.0) and [SDK experimental ^0.32.0](https://github.com/open-telemetry/opentelemetry-js/tree/experimental/v0.32.0)**
 ## Instrumentations
 | Instrumentation Package | Instrumented Lib | NPM |
 | --- | --- | --- |
@@ -64,6 +64,7 @@ The instrumentations in this repo are:
 
 | Instrumentations Version | OpenTelemetry Core | OpenTelemetry Experimental | 
 | --- | --- | --- |
+| 0.30.x | ^1.0.0 | ^0.32.0 |
 | 0.29.x | ^1.0.0 | ^0.29.0 |
 | 0.28.x | ^1.0.0 | ^0.28.0 |
 | 0.27.x | ^1.0.1 | ^0.27.0 |

--- a/packages/instrumentation-elasticsearch/package.json
+++ b/packages/instrumentation-elasticsearch/package.json
@@ -46,13 +46,13 @@
     },
     "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.0",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
     },
     "devDependencies": {
         "@elastic/elasticsearch": "^7.8.0",
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/contrib-test-utils": "^0.31.0",
+        "@opentelemetry/contrib-test-utils": "^0.32.0",
         "@types/chai": "^4.2.15",
         "@types/mocha": "^8.2.2",
         "chai": "^4.3.0",

--- a/packages/instrumentation-express/package.json
+++ b/packages/instrumentation-express/package.json
@@ -36,15 +36,15 @@
     },
     "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.0",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7"
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/contrib-test-utils": "^0.31.0",
-        "@opentelemetry/instrumentation-http": "^0.29.0",
+        "@opentelemetry/contrib-test-utils": "^0.32.0",
+        "@opentelemetry/instrumentation-http": "^0.32.0",
         "@opentelemetry/sdk-trace-base": "1.2.0",
         "@types/express": "4.17.8",
         "@types/mocha": "^8.2.2",

--- a/packages/instrumentation-kafkajs/package.json
+++ b/packages/instrumentation-kafkajs/package.json
@@ -38,12 +38,12 @@
         "@opentelemetry/api": "^1.0.0"
     },
     "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.0",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/contrib-test-utils": "^0.31.0",
+        "@opentelemetry/contrib-test-utils": "^0.32.0",
         "@opentelemetry/sdk-trace-base": "1.2.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",

--- a/packages/instrumentation-mongoose/package.json
+++ b/packages/instrumentation-mongoose/package.json
@@ -45,12 +45,12 @@
     },
     "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.0",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/contrib-test-utils": "^0.31.0",
+        "@opentelemetry/contrib-test-utils": "^0.32.0",
         "@opentelemetry/sdk-trace-base": "1.2.0",
         "@types/mocha": "^8.2.2",
         "@types/node": "^14.0.0",

--- a/packages/instrumentation-neo4j/package.json
+++ b/packages/instrumentation-neo4j/package.json
@@ -44,12 +44,12 @@
         "@opentelemetry/api": "^1.0.0"
     },
     "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.0",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/contrib-test-utils": "^0.31.0",
+        "@opentelemetry/contrib-test-utils": "^0.32.0",
         "@opentelemetry/sdk-trace-base": "1.2.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",

--- a/packages/instrumentation-node-cache/package.json
+++ b/packages/instrumentation-node-cache/package.json
@@ -43,12 +43,12 @@
     },
     "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.0",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/contrib-test-utils": "^0.31.0",
+        "@opentelemetry/contrib-test-utils": "^0.32.0",
         "@opentelemetry/sdk-trace-base": "1.2.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",

--- a/packages/instrumentation-sequelize/package.json
+++ b/packages/instrumentation-sequelize/package.json
@@ -43,12 +43,12 @@
     },
     "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.0",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/contrib-test-utils": "^0.31.0",
+        "@opentelemetry/contrib-test-utils": "^0.32.0",
         "@opentelemetry/sdk-trace-base": "1.2.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",

--- a/packages/instrumentation-socket.io/package.json
+++ b/packages/instrumentation-socket.io/package.json
@@ -44,14 +44,14 @@
         "@opentelemetry/api": "^1.0.0"
     },
     "dependencies": {
-        "@opentelemetry/instrumentation": "^0.29.0",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "is-promise": "^4.0.0"
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/contrib-test-utils": "^0.31.0",
-        "@opentelemetry/instrumentation-http": "^0.29.0",
+        "@opentelemetry/contrib-test-utils": "^0.32.0",
+        "@opentelemetry/instrumentation-http": "^0.32.0",
         "@opentelemetry/sdk-trace-base": "1.2.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",

--- a/packages/instrumentation-typeorm/package.json
+++ b/packages/instrumentation-typeorm/package.json
@@ -39,13 +39,13 @@
     },
     "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.29.0",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "is-promise": "^4.0.0"
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/contrib-test-utils": "^0.31.0",
+        "@opentelemetry/contrib-test-utils": "^0.32.0",
         "@opentelemetry/sdk-trace-base": "1.2.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",


### PR DESCRIPTION
Hi, thanks for the amazing libs!

This PR updates the core experimental version to 0.32.0. I used [this PR](https://github.com/aspecto-io/opentelemetry-ext-js/pull/234) as a base for my work.

I had some problems running tests locally for the mongoose and neo4j instrumentations, it seems I need to configure those tools in my local environment. 
Edit: Found the comments in the tests about how to setup Docker for those instrumentations, all tests have passed.

I also had some problems with peer dependencies like:

```
opentelemetry-instrumentation-elasticsearch@0.29.0" has unmet peer dependency "@opentelemetry/api@^1.0.0".
```

I ignored these errors because they happened before I even started updating deps. I am probably missing something basic as I have little knowledge of Yarn in a lerna project. I tried looking for a contributing guide but could not find it. If you have it, could you please link it here so I can follow?

I checked the release Changelogs for experimental packages on opentelemetry-js and it seems the packages here are not affected by the breaking changes. There are some deprecations to resolve but I think making a separate PR for them would be better as they require more effort and knowledge.