### PR TITLE
feat: upgrade instrumentations to otel 0.34.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The instrumentations in this repo are:
 - strictly complies with [open telemetry semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions)
 - up to date with latest SDK version
 
-**Compatible with [SDK stable ^1.0.0](https://github.com/open-telemetry/opentelemetry-js/tree/stable/v1.0.0) and [SDK experimental ^0.34.0](https://github.com/open-telemetry/opentelemetry-js/tree/experimental/v0.34.0)**
+**Compatible with [SDK stable ^1.8.0](https://github.com/open-telemetry/opentelemetry-js/tree/stable/v1.8.0) and [SDK experimental ^0.34.0](https://github.com/open-telemetry/opentelemetry-js/tree/experimental/v0.34.0)**
 ## Instrumentations
 | Instrumentation Package | Instrumented Lib | NPM |
 | --- | --- | --- |
@@ -64,7 +64,7 @@ The instrumentations in this repo are:
 
 | Instrumentations Version | OpenTelemetry Core | OpenTelemetry Experimental | 
 | --- | --- | --- |
-| 0.34.x | ^1.3.0 | ^0.34.0 |
+| 0.34.x | ^1.8.0 | ^0.34.0 |
 | 0.32.x | ^1.0.0 | ^0.32.0 |
 | 0.29.x | ^1.0.0 | ^0.29.0 |
 | 0.28.x | ^1.0.0 | ^0.28.0 |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The instrumentations in this repo are:
 - strictly complies with [open telemetry semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions)
 - up to date with latest SDK version
 
-**Compatible with [SDK stable ^1.0.0](https://github.com/open-telemetry/opentelemetry-js/tree/stable/v1.0.0) and [SDK experimental ^0.32.0](https://github.com/open-telemetry/opentelemetry-js/tree/experimental/v0.32.0)**
+**Compatible with [SDK stable ^1.0.0](https://github.com/open-telemetry/opentelemetry-js/tree/stable/v1.0.0) and [SDK experimental ^0.34.0](https://github.com/open-telemetry/opentelemetry-js/tree/experimental/v0.34.0)**
 ## Instrumentations
 | Instrumentation Package | Instrumented Lib | NPM |
 | --- | --- | --- |
@@ -64,6 +64,7 @@ The instrumentations in this repo are:
 
 | Instrumentations Version | OpenTelemetry Core | OpenTelemetry Experimental | 
 | --- | --- | --- |
+| 0.34.x | ^1.3.0 | ^0.34.0 |
 | 0.32.x | ^1.0.0 | ^0.32.0 |
 | 0.29.x | ^1.0.0 | ^0.29.0 |
 | 0.28.x | ^1.0.0 | ^0.28.0 |

--- a/packages/instrumentation-elasticsearch/package.json
+++ b/packages/instrumentation-elasticsearch/package.json
@@ -45,9 +45,9 @@
         "@opentelemetry/api": "^1.3.0"
     },
     "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
+        "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.34.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.8.0"
     },
     "devDependencies": {
         "@elastic/elasticsearch": "^7.8.0",

--- a/packages/instrumentation-elasticsearch/package.json
+++ b/packages/instrumentation-elasticsearch/package.json
@@ -42,17 +42,17 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
     },
     "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
     },
     "devDependencies": {
         "@elastic/elasticsearch": "^7.8.0",
-        "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/contrib-test-utils": "^0.32.0",
+        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/contrib-test-utils": "^0.33.0",
         "@types/chai": "^4.2.15",
         "@types/mocha": "^8.2.2",
         "chai": "^4.3.0",

--- a/packages/instrumentation-express/package.json
+++ b/packages/instrumentation-express/package.json
@@ -35,9 +35,9 @@
         "@opentelemetry/api": "^1.3.0"
     },
     "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
+        "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.34.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.8.0",
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7"
     },

--- a/packages/instrumentation-express/package.json
+++ b/packages/instrumentation-express/package.json
@@ -32,20 +32,20 @@
         "access": "public"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
     },
     "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/contrib-test-utils": "^0.32.0",
-        "@opentelemetry/instrumentation-http": "^0.32.0",
-        "@opentelemetry/sdk-trace-base": "1.2.0",
+        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/contrib-test-utils": "^0.33.0",
+        "@opentelemetry/instrumentation-http": "^0.34.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0",
         "@types/express": "4.17.8",
         "@types/mocha": "^8.2.2",
         "axios": "0.21.1",

--- a/packages/instrumentation-kafkajs/package.json
+++ b/packages/instrumentation-kafkajs/package.json
@@ -39,7 +39,7 @@
     },
     "dependencies": {
         "@opentelemetry/instrumentation": "^0.34.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.8.0"
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.3.0",

--- a/packages/instrumentation-kafkajs/package.json
+++ b/packages/instrumentation-kafkajs/package.json
@@ -35,16 +35,16 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
     },
     "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/contrib-test-utils": "^0.32.0",
-        "@opentelemetry/sdk-trace-base": "1.2.0",
+        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/contrib-test-utils": "^0.33.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "kafkajs": "^1.12.0",

--- a/packages/instrumentation-mongoose/package.json
+++ b/packages/instrumentation-mongoose/package.json
@@ -44,9 +44,9 @@
         "@opentelemetry/api": "^1.3.0"
     },
     "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
+        "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.34.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.8.0"
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.3.0",

--- a/packages/instrumentation-mongoose/package.json
+++ b/packages/instrumentation-mongoose/package.json
@@ -41,17 +41,17 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
     },
     "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/contrib-test-utils": "^0.32.0",
-        "@opentelemetry/sdk-trace-base": "1.2.0",
+        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/contrib-test-utils": "^0.33.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0",
         "@types/mocha": "^8.2.2",
         "@types/node": "^14.0.0",
         "expect": "^26.6.2",

--- a/packages/instrumentation-neo4j/package.json
+++ b/packages/instrumentation-neo4j/package.json
@@ -41,16 +41,16 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
     },
     "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/contrib-test-utils": "^0.32.0",
-        "@opentelemetry/sdk-trace-base": "1.2.0",
+        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/contrib-test-utils": "^0.33.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/packages/instrumentation-neo4j/package.json
+++ b/packages/instrumentation-neo4j/package.json
@@ -45,7 +45,7 @@
     },
     "dependencies": {
         "@opentelemetry/instrumentation": "^0.34.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.8.0"
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.3.0",

--- a/packages/instrumentation-node-cache/package.json
+++ b/packages/instrumentation-node-cache/package.json
@@ -39,17 +39,17 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
     },
     "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/contrib-test-utils": "^0.32.0",
-        "@opentelemetry/sdk-trace-base": "1.2.0",
+        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/contrib-test-utils": "^0.33.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/packages/instrumentation-node-cache/package.json
+++ b/packages/instrumentation-node-cache/package.json
@@ -42,9 +42,9 @@
         "@opentelemetry/api": "^1.3.0"
     },
     "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
+        "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.34.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.8.0"
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.3.0",

--- a/packages/instrumentation-sequelize/package.json
+++ b/packages/instrumentation-sequelize/package.json
@@ -39,17 +39,17 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
     },
     "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/contrib-test-utils": "^0.32.0",
-        "@opentelemetry/sdk-trace-base": "1.2.0",
+        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/contrib-test-utils": "^0.33.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/packages/instrumentation-sequelize/package.json
+++ b/packages/instrumentation-sequelize/package.json
@@ -42,9 +42,9 @@
         "@opentelemetry/api": "^1.3.0"
     },
     "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
+        "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.34.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.8.0"
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.3.0",

--- a/packages/instrumentation-socket.io/package.json
+++ b/packages/instrumentation-socket.io/package.json
@@ -41,18 +41,18 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
     },
     "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "is-promise": "^4.0.0"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/contrib-test-utils": "^0.32.0",
-        "@opentelemetry/instrumentation-http": "^0.32.0",
-        "@opentelemetry/sdk-trace-base": "1.2.0",
+        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/contrib-test-utils": "^0.33.0",
+        "@opentelemetry/instrumentation-http": "^0.34.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/packages/instrumentation-socket.io/package.json
+++ b/packages/instrumentation-socket.io/package.json
@@ -45,7 +45,7 @@
     },
     "dependencies": {
         "@opentelemetry/instrumentation": "^0.34.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.8.0",
         "is-promise": "^4.0.0"
     },
     "devDependencies": {

--- a/packages/instrumentation-typeorm/package.json
+++ b/packages/instrumentation-typeorm/package.json
@@ -35,18 +35,18 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
     },
     "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "is-promise": "^4.0.0"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/contrib-test-utils": "^0.32.0",
-        "@opentelemetry/sdk-trace-base": "1.2.0",
+        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/contrib-test-utils": "^0.33.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/packages/instrumentation-typeorm/package.json
+++ b/packages/instrumentation-typeorm/package.json
@@ -38,9 +38,9 @@
         "@opentelemetry/api": "^1.3.0"
     },
     "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
+        "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.34.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.8.0",
         "is-promise": "^4.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Upgrade to latest `@opentelemetry/instrumentation` which has a peer dependency on `@opentelemetry/api@1.3.0`. `@opentelemetry/sdk-trace-base` in the dev deps had `@opentelemetry/api` pinned to `>= 1 <1.2.0` so I upgraded it to the latest version as well.