### PR TITLE
fix: otel context propagation

### DIFF
--- a/detectors/node/resource-detector-deployment/package.json
+++ b/detectors/node/resource-detector-deployment/package.json
@@ -36,7 +36,7 @@
         "@opentelemetry/api": "^1.6.0"
     },
     "dependencies": {
-        "@opentelemetry/resources": "~1.17.1",
+        "@opentelemetry/resources": "^1.17.1",
         "@opentelemetry/semantic-conventions": "^1.17.1",
         "opentelemetry-resource-detector-sync-api": "^0.29.0"
     },

--- a/detectors/node/resource-detector-git/package.json
+++ b/detectors/node/resource-detector-git/package.json
@@ -37,7 +37,7 @@
         "@opentelemetry/api": "^1.6.0"
     },
     "dependencies": {
-        "@opentelemetry/resources": "~1.17.1",
+        "@opentelemetry/resources": "^1.17.1",
         "@opentelemetry/semantic-conventions": "^1.17.1",
         "opentelemetry-resource-detector-sync-api": "^0.29.0",
         "uuid": "^8.3.2"

--- a/detectors/node/resource-detector-service/package.json
+++ b/detectors/node/resource-detector-service/package.json
@@ -36,7 +36,7 @@
         "@opentelemetry/api": "^1.6.0"
     },
     "dependencies": {
-        "@opentelemetry/resources": "~1.17.1",
+        "@opentelemetry/resources": "^1.17.1",
         "@opentelemetry/semantic-conventions": "^1.17.1",
         "opentelemetry-resource-detector-sync-api": "^0.29.0",
         "uuid": "^8.3.2"

--- a/detectors/resource-detector-sync-api/package.json
+++ b/detectors/resource-detector-sync-api/package.json
@@ -33,7 +33,7 @@
         "@opentelemetry/api": "^1.6.0"
     },
     "dependencies": {
-        "@opentelemetry/resources": "~1.17.1"
+        "@opentelemetry/resources": "^1.17.1"
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.6.0",

--- a/packages/instrumentation-elasticsearch/package.json
+++ b/packages/instrumentation-elasticsearch/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@opentelemetry/core": "^1.17.1",
-        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/instrumentation": "^0.45.1",
         "@opentelemetry/semantic-conventions": "^1.17.1"
     },
     "devDependencies": {

--- a/packages/instrumentation-express/package.json
+++ b/packages/instrumentation-express/package.json
@@ -36,7 +36,7 @@
     },
     "dependencies": {
         "@opentelemetry/core": "^1.17.1",
-        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/instrumentation": "^0.45.1",
         "@opentelemetry/semantic-conventions": "^1.17.1",
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7"

--- a/packages/instrumentation-kafkajs/package.json
+++ b/packages/instrumentation-kafkajs/package.json
@@ -38,7 +38,7 @@
         "@opentelemetry/api": "^1.6.0"
     },
     "dependencies": {
-        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/instrumentation": "^0.45.1",
         "@opentelemetry/semantic-conventions": "^1.17.1"
     },
     "devDependencies": {

--- a/packages/instrumentation-kafkajs/src/kafkajs.ts
+++ b/packages/instrumentation-kafkajs/src/kafkajs.ts
@@ -8,7 +8,6 @@ import {
     trace,
     context,
     diag,
-    ROOT_CONTEXT,
 } from '@opentelemetry/api';
 import {
     SemanticAttributes,
@@ -137,7 +136,7 @@ export class KafkaJsInstrumentation extends InstrumentationBase<typeof kafkaJs> 
         const self = this;
         return function (payload: EachMessagePayload): Promise<void> {
             const propagatedContext: Context = propagation.extract(
-                ROOT_CONTEXT,
+                context.active(),
                 payload.message.headers,
                 bufferTextMapGetter
             );
@@ -163,12 +162,12 @@ export class KafkaJsInstrumentation extends InstrumentationBase<typeof kafkaJs> 
                 payload.batch.topic,
                 undefined,
                 MessagingOperationValues.RECEIVE,
-                ROOT_CONTEXT
+                context.active()
             );
             return context.with(trace.setSpan(context.active(), receivingSpan), () => {
                 const spans = payload.batch.messages.map((message: KafkaMessage) => {
                     const propagatedContext: Context = propagation.extract(
-                        ROOT_CONTEXT,
+                        context.active(),
                         message.headers,
                         bufferTextMapGetter
                     );

--- a/packages/instrumentation-kafkajs/src/kafkajs.ts
+++ b/packages/instrumentation-kafkajs/src/kafkajs.ts
@@ -1,14 +1,4 @@
-import {
-    SpanKind,
-    Span,
-    SpanStatusCode,
-    Context,
-    propagation,
-    Link,
-    trace,
-    context,
-    diag,
-} from '@opentelemetry/api';
+import { SpanKind, Span, SpanStatusCode, Context, propagation, Link, trace, context, diag } from '@opentelemetry/api';
 import {
     SemanticAttributes,
     MessagingOperationValues,

--- a/packages/instrumentation-kafkajs/test/kafkajs.spec.ts
+++ b/packages/instrumentation-kafkajs/test/kafkajs.spec.ts
@@ -5,6 +5,7 @@ import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { propagation, context, SpanKind, SpanStatusCode, Span } from '@opentelemetry/api';
 import { MessagingDestinationKindValues, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { getTestSpans, registerInstrumentationTesting } from '@opentelemetry/contrib-test-utils';
+import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 
 const instrumentation = registerInstrumentationTesting(new KafkaJsInstrumentation());
 
@@ -26,6 +27,7 @@ import { DummyPropagation } from './DummyPropagation';
 import { W3CBaggagePropagator, CompositePropagator } from '@opentelemetry/core';
 
 describe('instrumentation-kafkajs', () => {
+    context.setGlobalContextManager(new AsyncHooksContextManager());
     propagation.setGlobalPropagator(
         new CompositePropagator({ propagators: [new DummyPropagation(), new W3CBaggagePropagator()] })
     );

--- a/packages/instrumentation-neo4j/package.json
+++ b/packages/instrumentation-neo4j/package.json
@@ -44,7 +44,7 @@
         "@opentelemetry/api": "^1.6.0"
     },
     "dependencies": {
-        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/instrumentation": "^0.45.1",
         "@opentelemetry/semantic-conventions": "^1.17.1"
     },
     "devDependencies": {

--- a/packages/instrumentation-node-cache/package.json
+++ b/packages/instrumentation-node-cache/package.json
@@ -44,7 +44,7 @@
     "dependencies": {
         "@opentelemetry/contrib-test-utils": "^0.34.2",
         "@opentelemetry/core": "^1.17.1",
-        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/instrumentation": "^0.45.1",
         "@opentelemetry/semantic-conventions": "^1.17.1"
     },
     "devDependencies": {

--- a/packages/instrumentation-sequelize/package.json
+++ b/packages/instrumentation-sequelize/package.json
@@ -43,7 +43,7 @@
     },
     "dependencies": {
         "@opentelemetry/core": "^1.17.1",
-        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/instrumentation": "^0.45.1",
         "@opentelemetry/semantic-conventions": "^1.17.1"
     },
     "devDependencies": {

--- a/packages/instrumentation-typeorm/package.json
+++ b/packages/instrumentation-typeorm/package.json
@@ -39,7 +39,7 @@
     },
     "dependencies": {
         "@opentelemetry/core": "^1.17.1",
-        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/instrumentation": "^0.45.1",
         "@opentelemetry/semantic-conventions": "^1.17.1",
         "is-promise": "^4.0.0"
     },


### PR DESCRIPTION
The ROOT_CONTEXT is readonly, thus any updates into it would be no-ops
Instead, the currently _active_ context should be used for propagation