### PR TITLE
upgrade otel versions

### DIFF
--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -24,12 +24,12 @@ jobs:
           - 27017:27017
 
       neo4j:
-        image: neo4j:4.2.3
+        image: neo4j:4.4.34
         ports:
           - 7474:7474
           - 11011:7687
         env:
-          NEO4J_AUTH: neo4j/test
+          NEO4J_AUTH: neo4j/your_password
 
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,10 +39,10 @@ jobs:
       - name: Fetch all history for all tags and branches
         run: git fetch
 
-      - name: Use Node.js 14
+      - name: Use Node.js 18
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 18
 
       - name: Install Dependencies
         run: yarn install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,12 @@ jobs:
           - 27017:27017
 
       neo4j:
-        image: neo4j:4.2.3
+        image: neo4j:4.4.34
         ports:
           - 7474:7474
           - 11011:7687
         env:
-          NEO4J_AUTH: neo4j/test
+          NEO4J_AUTH: neo4j/your_password
 
     steps:
 

--- a/detectors/node/resource-detector-deployment/package.json
+++ b/detectors/node/resource-detector-deployment/package.json
@@ -45,7 +45,7 @@
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
-        "opentelemetry-instrumentation-mocha": "0.0.7-alpha.1",
+        "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "ts-node": "^9.1.1",
         "typescript": "4.3.4"
     },
@@ -56,7 +56,7 @@
         "spec": "test/**/*.spec.ts",
         "require": [
             "ts-node/register",
-            "opentelemetry-instrumentation-mocha"
+            "aspecto-opentelemetry-instrumentation-mocha"
         ]
     }
 }

--- a/detectors/node/resource-detector-deployment/package.json
+++ b/detectors/node/resource-detector-deployment/package.json
@@ -33,15 +33,15 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.6.0"
+        "@opentelemetry/api": "^1.8.0"
     },
     "dependencies": {
-        "@opentelemetry/resources": "~1.17.1",
-        "@opentelemetry/semantic-conventions": "^1.17.1",
+        "@opentelemetry/resources": "~1.24.1",
+        "@opentelemetry/semantic-conventions": "^1.24.1",
         "opentelemetry-resource-detector-sync-api": "^0.29.0"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.6.0",
+        "@opentelemetry/api": "^1.8.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/detectors/node/resource-detector-deployment/package.json
+++ b/detectors/node/resource-detector-deployment/package.json
@@ -46,7 +46,7 @@
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
         "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
-        "ts-node": "^9.1.1",
+        "ts-node": "^10.9.2",
         "typescript": "5.4.5"
     },
     "mocha": {

--- a/detectors/node/resource-detector-deployment/package.json
+++ b/detectors/node/resource-detector-deployment/package.json
@@ -47,7 +47,7 @@
         "mocha": "^8.4.0",
         "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "ts-node": "^9.1.1",
-        "typescript": "4.3.4"
+        "typescript": "5.4.5"
     },
     "mocha": {
         "extension": [

--- a/detectors/node/resource-detector-git/package.json
+++ b/detectors/node/resource-detector-git/package.json
@@ -34,16 +34,16 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.6.0"
+        "@opentelemetry/api": "^1.8.0"
     },
     "dependencies": {
-        "@opentelemetry/resources": "~1.17.1",
-        "@opentelemetry/semantic-conventions": "^1.17.1",
+        "@opentelemetry/resources": "~1.24.1",
+        "@opentelemetry/semantic-conventions": "^1.24.1",
         "opentelemetry-resource-detector-sync-api": "^0.29.0",
         "uuid": "^8.3.2"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.6.0",
+        "@opentelemetry/api": "^1.8.0",
         "@types/mocha": "^8.2.2",
         "@types/node": "^14.0.0",
         "expect": "^26.6.2",

--- a/detectors/node/resource-detector-git/package.json
+++ b/detectors/node/resource-detector-git/package.json
@@ -51,7 +51,7 @@
         "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "sinon": "^11.1.1",
         "ts-node": "^9.1.1",
-        "typescript": "4.3.4"
+        "typescript": "5.4.5"
     },
     "mocha": {
         "extension": [

--- a/detectors/node/resource-detector-git/package.json
+++ b/detectors/node/resource-detector-git/package.json
@@ -48,7 +48,7 @@
         "@types/node": "^14.0.0",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
-        "opentelemetry-instrumentation-mocha": "0.0.7-alpha.1",
+        "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "sinon": "^11.1.1",
         "ts-node": "^9.1.1",
         "typescript": "4.3.4"
@@ -60,7 +60,7 @@
         "spec": "test/**/*.spec.ts",
         "require": [
             "ts-node/register",
-            "opentelemetry-instrumentation-mocha"
+            "aspecto-opentelemetry-instrumentation-mocha"
         ]
     }
 }

--- a/detectors/node/resource-detector-git/package.json
+++ b/detectors/node/resource-detector-git/package.json
@@ -50,7 +50,7 @@
         "mocha": "^8.4.0",
         "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "sinon": "^11.1.1",
-        "ts-node": "^9.1.1",
+        "ts-node": "^10.9.2",
         "typescript": "5.4.5"
     },
     "mocha": {

--- a/detectors/node/resource-detector-service/package.json
+++ b/detectors/node/resource-detector-service/package.json
@@ -48,7 +48,7 @@
         "mocha": "^8.4.0",
         "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "ts-node": "^9.1.1",
-        "typescript": "4.3.4"
+        "typescript": "5.4.5"
     },
     "mocha": {
         "extension": [

--- a/detectors/node/resource-detector-service/package.json
+++ b/detectors/node/resource-detector-service/package.json
@@ -33,16 +33,16 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.6.0"
+        "@opentelemetry/api": "^1.8.0"
     },
     "dependencies": {
-        "@opentelemetry/resources": "~1.17.1",
-        "@opentelemetry/semantic-conventions": "^1.17.1",
+        "@opentelemetry/resources": "~1.24.1",
+        "@opentelemetry/semantic-conventions": "^1.24.1",
         "opentelemetry-resource-detector-sync-api": "^0.29.0",
         "uuid": "^8.3.2"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.6.0",
+        "@opentelemetry/api": "^1.8.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/detectors/node/resource-detector-service/package.json
+++ b/detectors/node/resource-detector-service/package.json
@@ -46,7 +46,7 @@
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
-        "opentelemetry-instrumentation-mocha": "0.0.7-alpha.1",
+        "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "ts-node": "^9.1.1",
         "typescript": "4.3.4"
     },
@@ -57,7 +57,7 @@
         "spec": "test/**/*.spec.ts",
         "require": [
             "ts-node/register",
-            "opentelemetry-instrumentation-mocha"
+            "aspecto-opentelemetry-instrumentation-mocha"
         ]
     }
 }

--- a/detectors/node/resource-detector-service/package.json
+++ b/detectors/node/resource-detector-service/package.json
@@ -47,7 +47,7 @@
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
         "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
-        "ts-node": "^9.1.1",
+        "ts-node": "^10.9.2",
         "typescript": "5.4.5"
     },
     "mocha": {

--- a/detectors/resource-detector-sync-api/package.json
+++ b/detectors/resource-detector-sync-api/package.json
@@ -38,6 +38,6 @@
     "devDependencies": {
         "@opentelemetry/api": "^1.8.0",
         "ts-node": "^9.1.1",
-        "typescript": "4.3.4"
+        "typescript": "5.4.5"
     }
 }

--- a/detectors/resource-detector-sync-api/package.json
+++ b/detectors/resource-detector-sync-api/package.json
@@ -30,13 +30,13 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.6.0"
+        "@opentelemetry/api": "^1.8.0"
     },
     "dependencies": {
         "@opentelemetry/resources": "~1.17.1"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.6.0",
+        "@opentelemetry/api": "^1.8.0",
         "ts-node": "^9.1.1",
         "typescript": "4.3.4"
     }

--- a/detectors/resource-detector-sync-api/package.json
+++ b/detectors/resource-detector-sync-api/package.json
@@ -33,7 +33,7 @@
         "@opentelemetry/api": "^1.8.0"
     },
     "dependencies": {
-        "@opentelemetry/resources": "~1.17.1"
+        "@opentelemetry/resources": "~1.24.1"
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.8.0",

--- a/detectors/resource-detector-sync-api/package.json
+++ b/detectors/resource-detector-sync-api/package.json
@@ -37,7 +37,7 @@
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.8.0",
-        "ts-node": "^9.1.1",
+        "ts-node": "^10.9.2",
         "typescript": "5.4.5"
     }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,5 @@
 {
     "packages": ["packages/*", "detectors/*", "detectors/node/*", "propagators/*", "examples/*"],
     "version": "independent",
-    "npmClient": "yarn",
-    "useWorkspaces": true
+    "npmClient": "yarn"
 }

--- a/package.json
+++ b/package.json
@@ -8,17 +8,17 @@
         "test:ci:all": "lerna run test:ci --parallel",
         "build": "lerna run build",
         "build:ci": "lerna run build",
-        "postinstall": "lerna bootstrap",
         "prettier": "prettier --config .prettierrc.yml --write --ignore-unknown \"**/*\"",
-        "prettier:check": "npx prettier@2.3.2 --config .prettierrc.yml --check --ignore-unknown \"**/*\"",
+        "prettier:check": "npx prettier@3.2.5 --config .prettierrc.yml --check --ignore-unknown \"**/*\"",
         "version:update": "lerna run version:update",
         "version": "git add packages/**/version.ts",
         "publish:ci": "lerna publish --yes --allow-branch master --create-release github --conventionalCommits",
         "publish:ci:prerelease": "lerna publish --yes --no-git-tag-version --no-push --no-changelog --dist-tag alpha"
     },
     "devDependencies": {
-        "lerna": "^3.22.1",
-        "prettier": "2.3.2"
+        "@types/node": "^20.12.12",
+        "lerna": "^8.1.3",
+        "prettier": "3.2.5"
     },
     "workspaces": [
         "packages/*",

--- a/packages/instrumentation-elasticsearch/package.json
+++ b/packages/instrumentation-elasticsearch/package.json
@@ -62,7 +62,7 @@
         "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "sinon": "^9.2.4",
         "test-all-versions": "^5.0.1",
-        "ts-node": "^9.1.1",
+        "ts-node": "^10.9.2",
         "typescript": "5.4.5"
     },
     "mocha": {

--- a/packages/instrumentation-elasticsearch/package.json
+++ b/packages/instrumentation-elasticsearch/package.json
@@ -63,7 +63,7 @@
         "sinon": "^9.2.4",
         "test-all-versions": "^5.0.1",
         "ts-node": "^9.1.1",
-        "typescript": "4.3.4"
+        "typescript": "5.4.5"
     },
     "mocha": {
         "extension": [

--- a/packages/instrumentation-elasticsearch/package.json
+++ b/packages/instrumentation-elasticsearch/package.json
@@ -42,16 +42,16 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.6.0"
+        "@opentelemetry/api": "^1.8.0"
     },
     "dependencies": {
-        "@opentelemetry/core": "^1.17.1",
-        "@opentelemetry/instrumentation": "^0.44.0",
-        "@opentelemetry/semantic-conventions": "^1.17.1"
+        "@opentelemetry/core": "^1.24.1",
+        "@opentelemetry/instrumentation": "^0.51.1",
+        "@opentelemetry/semantic-conventions": "^1.24.1"
     },
     "devDependencies": {
         "@elastic/elasticsearch": "^7.8.0",
-        "@opentelemetry/api": "^1.6.0",
+        "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.34.2",
         "@types/chai": "^4.2.15",
         "@types/mocha": "^8.2.2",

--- a/packages/instrumentation-elasticsearch/package.json
+++ b/packages/instrumentation-elasticsearch/package.json
@@ -52,7 +52,7 @@
     "devDependencies": {
         "@elastic/elasticsearch": "^7.8.0",
         "@opentelemetry/api": "^1.8.0",
-        "@opentelemetry/contrib-test-utils": "^0.34.2",
+        "@opentelemetry/contrib-test-utils": "^0.39.0",
         "@types/chai": "^4.2.15",
         "@types/mocha": "^8.2.2",
         "chai": "^4.3.0",

--- a/packages/instrumentation-elasticsearch/package.json
+++ b/packages/instrumentation-elasticsearch/package.json
@@ -59,7 +59,7 @@
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
         "nock": "^13.0.9",
-        "opentelemetry-instrumentation-mocha": "0.0.7-alpha.1",
+        "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "sinon": "^9.2.4",
         "test-all-versions": "^5.0.1",
         "ts-node": "^9.1.1",
@@ -72,7 +72,7 @@
         "spec": "test/**/*.spec.ts",
         "require": [
             "ts-node/register",
-            "opentelemetry-instrumentation-mocha"
+            "aspecto-opentelemetry-instrumentation-mocha"
         ]
     }
 }

--- a/packages/instrumentation-elasticsearch/src/elasticsearch.ts
+++ b/packages/instrumentation-elasticsearch/src/elasticsearch.ts
@@ -21,7 +21,7 @@ import {
 } from './utils';
 import { ELASTICSEARCH_API_FILES } from './helpers';
 
-export class ElasticsearchInstrumentation extends InstrumentationBase<typeof elasticsearch> {
+export class ElasticsearchInstrumentation extends InstrumentationBase {
     static readonly component = '@elastic/elasticsearch';
 
     protected override _config: ElasticsearchInstrumentationConfig;
@@ -36,10 +36,10 @@ export class ElasticsearchInstrumentation extends InstrumentationBase<typeof ela
         this._config = Object.assign({}, config);
     }
 
-    protected init(): InstrumentationModuleDefinition<typeof elasticsearch> {
+    protected init(): InstrumentationModuleDefinition {
         const apiModuleFiles = ELASTICSEARCH_API_FILES.map(
             ({ path, operationClassName }) =>
-                new InstrumentationNodeModuleFile<any>(
+                new InstrumentationNodeModuleFile(
                     `@elastic/elasticsearch/api/${path}`,
                     ['>=5 <8'],
                     this.patch.bind(this, operationClassName),
@@ -47,7 +47,7 @@ export class ElasticsearchInstrumentation extends InstrumentationBase<typeof ela
                 )
         );
 
-        const module = new InstrumentationNodeModuleDefinition<typeof elasticsearch>(
+        const module = new InstrumentationNodeModuleDefinition(
             ElasticsearchInstrumentation.component,
             ['*'],
             undefined,

--- a/packages/instrumentation-elasticsearch/src/elasticsearch.ts
+++ b/packages/instrumentation-elasticsearch/src/elasticsearch.ts
@@ -122,9 +122,11 @@ export class ElasticsearchInstrumentation extends InstrumentationBase {
                 attributes: {
                     [SEMATTRS_DB_OPERATION]: operation,
                     [AttributeNames.ELASTICSEARCH_INDICES]: getIndexName(params),
-                    [SEMATTRS_DB_STATEMENT]: (
-                        self._config.dbStatementSerializer || defaultDbStatementSerializer
-                    )(operation, params, options),
+                    [SEMATTRS_DB_STATEMENT]: (self._config.dbStatementSerializer || defaultDbStatementSerializer)(
+                        operation,
+                        params,
+                        options
+                    ),
                 },
             });
             self._addModuleVersionIfNeeded(span);

--- a/packages/instrumentation-elasticsearch/src/elasticsearch.ts
+++ b/packages/instrumentation-elasticsearch/src/elasticsearch.ts
@@ -10,7 +10,7 @@ import {
 } from '@opentelemetry/instrumentation';
 import { VERSION } from './version';
 import { AttributeNames } from './enums';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_DB_OPERATION, SEMATTRS_DB_STATEMENT, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import {
     startSpan,
     onError,
@@ -120,9 +120,9 @@ export class ElasticsearchInstrumentation extends InstrumentationBase {
             const span = startSpan({
                 tracer: self.tracer,
                 attributes: {
-                    [SemanticAttributes.DB_OPERATION]: operation,
+                    [SEMATTRS_DB_OPERATION]: operation,
                     [AttributeNames.ELASTICSEARCH_INDICES]: getIndexName(params),
-                    [SemanticAttributes.DB_STATEMENT]: (
+                    [SEMATTRS_DB_STATEMENT]: (
                         self._config.dbStatementSerializer || defaultDbStatementSerializer
                     )(operation, params, options),
                 },

--- a/packages/instrumentation-elasticsearch/src/utils.ts
+++ b/packages/instrumentation-elasticsearch/src/utils.ts
@@ -1,7 +1,7 @@
 import { Tracer, SpanAttributes, SpanStatusCode, diag, Span, SpanKind } from '@opentelemetry/api';
 import { DbStatementSerializer, ResponseHook } from './types';
 import { safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_DB_SYSTEM, SEMATTRS_NET_PEER_NAME, SEMATTRS_NET_PEER_PORT, SEMATTRS_NET_TRANSPORT } from '@opentelemetry/semantic-conventions';
 import { ApiResponse } from '@elastic/elasticsearch/lib/Transport';
 
 interface StartSpanPayload {
@@ -27,7 +27,7 @@ export function startSpan({ tracer, attributes }: StartSpanPayload): Span {
     return tracer.startSpan('elasticsearch.request', {
         kind: SpanKind.CLIENT,
         attributes: {
-            [SemanticAttributes.DB_SYSTEM]: 'elasticsearch',
+            [SEMATTRS_DB_SYSTEM]: 'elasticsearch',
             ...attributes,
         },
     });
@@ -60,9 +60,9 @@ export function getNetAttributes(url: string): SpanAttributes {
     const { port, protocol, hostname } = new URL(url);
 
     return {
-        [SemanticAttributes.NET_TRANSPORT]: 'IP.TCP',
-        [SemanticAttributes.NET_PEER_NAME]: hostname,
-        [SemanticAttributes.NET_PEER_PORT]: getPort(port, protocol),
+        [SEMATTRS_NET_TRANSPORT]: 'IP.TCP',
+        [SEMATTRS_NET_PEER_NAME]: hostname,
+        [SEMATTRS_NET_PEER_PORT]: getPort(port, protocol),
     };
 }
 

--- a/packages/instrumentation-elasticsearch/src/utils.ts
+++ b/packages/instrumentation-elasticsearch/src/utils.ts
@@ -1,7 +1,12 @@
 import { Tracer, SpanAttributes, SpanStatusCode, diag, Span, SpanKind } from '@opentelemetry/api';
 import { DbStatementSerializer, ResponseHook } from './types';
 import { safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
-import { SEMATTRS_DB_SYSTEM, SEMATTRS_NET_PEER_NAME, SEMATTRS_NET_PEER_PORT, SEMATTRS_NET_TRANSPORT } from '@opentelemetry/semantic-conventions';
+import {
+    SEMATTRS_DB_SYSTEM,
+    SEMATTRS_NET_PEER_NAME,
+    SEMATTRS_NET_PEER_PORT,
+    SEMATTRS_NET_TRANSPORT,
+} from '@opentelemetry/semantic-conventions';
 import { ApiResponse } from '@elastic/elasticsearch/lib/Transport';
 
 interface StartSpanPayload {

--- a/packages/instrumentation-elasticsearch/test/utils.spec.ts
+++ b/packages/instrumentation-elasticsearch/test/utils.spec.ts
@@ -3,7 +3,11 @@ import { stub, assert, spy } from 'sinon';
 import { expect } from 'chai';
 import * as Utils from '../src/utils';
 import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
-import { SEMATTRS_DB_SYSTEM, SEMATTRS_NET_PEER_NAME, SEMATTRS_NET_PEER_PORT } from '@opentelemetry/semantic-conventions';
+import {
+    SEMATTRS_DB_SYSTEM,
+    SEMATTRS_NET_PEER_NAME,
+    SEMATTRS_NET_PEER_PORT,
+} from '@opentelemetry/semantic-conventions';
 
 describe('elasticsearch utils', () => {
     const spanMock = {

--- a/packages/instrumentation-elasticsearch/test/utils.spec.ts
+++ b/packages/instrumentation-elasticsearch/test/utils.spec.ts
@@ -7,6 +7,7 @@ import {
     SEMATTRS_DB_SYSTEM,
     SEMATTRS_NET_PEER_NAME,
     SEMATTRS_NET_PEER_PORT,
+    SEMATTRS_NET_TRANSPORT,
 } from '@opentelemetry/semantic-conventions';
 
 describe('elasticsearch utils', () => {
@@ -104,7 +105,7 @@ describe('elasticsearch utils', () => {
         });
 
         it('should set net.transport', () => {
-            expect(attributes[SEMATTRS_NET_PEER_PORT]).to.equal('IP.TCP');
+            expect(attributes[SEMATTRS_NET_TRANSPORT]).to.equal('IP.TCP');
         });
     });
 

--- a/packages/instrumentation-elasticsearch/test/utils.spec.ts
+++ b/packages/instrumentation-elasticsearch/test/utils.spec.ts
@@ -3,7 +3,7 @@ import { stub, assert, spy } from 'sinon';
 import { expect } from 'chai';
 import * as Utils from '../src/utils';
 import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_DB_SYSTEM, SEMATTRS_NET_PEER_NAME, SEMATTRS_NET_PEER_PORT } from '@opentelemetry/semantic-conventions';
 
 describe('elasticsearch utils', () => {
     const spanMock = {
@@ -92,15 +92,15 @@ describe('elasticsearch utils', () => {
         const attributes = Utils.getNetAttributes(url);
 
         it('should get hostname from url', () => {
-            expect(attributes[SemanticAttributes.NET_PEER_NAME]).to.equal('localhost');
+            expect(attributes[SEMATTRS_NET_PEER_NAME]).to.equal('localhost');
         });
 
         it('should get hostname from url', () => {
-            expect(attributes[SemanticAttributes.NET_PEER_PORT]).to.equal('9200');
+            expect(attributes[SEMATTRS_NET_PEER_PORT]).to.equal('9200');
         });
 
         it('should set net.transport', () => {
-            expect(attributes[SemanticAttributes.NET_TRANSPORT]).to.equal('IP.TCP');
+            expect(attributes[SEMATTRS_NET_PEER_PORT]).to.equal('IP.TCP');
         });
     });
 
@@ -190,7 +190,7 @@ describe('elasticsearch utils', () => {
 
             expect(operation).to.equal('elasticsearch.request');
             expect(options.kind).to.equal(SpanKind.CLIENT);
-            expect(options.attributes[SemanticAttributes.DB_SYSTEM]).to.equal('elasticsearch');
+            expect(options.attributes[SEMATTRS_DB_SYSTEM]).to.equal('elasticsearch');
             expect(options.attributes.testAttribute).to.equal('testValue');
         });
     });

--- a/packages/instrumentation-express/package.json
+++ b/packages/instrumentation-express/package.json
@@ -56,7 +56,7 @@
         "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "test-all-versions": "^5.0.1",
         "ts-node": "^9.1.1",
-        "typescript": "4.3.4"
+        "typescript": "5.4.5"
     },
     "mocha": {
         "extension": [

--- a/packages/instrumentation-express/package.json
+++ b/packages/instrumentation-express/package.json
@@ -53,7 +53,7 @@
         "expect": "^26.6.2",
         "express": "4.17.1",
         "mocha": "^8.4.0",
-        "opentelemetry-instrumentation-mocha": "0.0.7-alpha.1",
+        "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "test-all-versions": "^5.0.1",
         "ts-node": "^9.1.1",
         "typescript": "4.3.4"
@@ -65,7 +65,7 @@
         "spec": "test/**/*.spec.ts",
         "require": [
             "ts-node/register",
-            "opentelemetry-instrumentation-mocha"
+            "aspecto-opentelemetry-instrumentation-mocha"
         ]
     }
 }

--- a/packages/instrumentation-express/package.json
+++ b/packages/instrumentation-express/package.json
@@ -55,7 +55,7 @@
         "mocha": "^8.4.0",
         "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "test-all-versions": "^5.0.1",
-        "ts-node": "^9.1.1",
+        "ts-node": "^10.9.2",
         "typescript": "5.4.5"
     },
     "mocha": {

--- a/packages/instrumentation-express/package.json
+++ b/packages/instrumentation-express/package.json
@@ -43,7 +43,7 @@
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.8.0",
-        "@opentelemetry/contrib-test-utils": "^0.34.2",
+        "@opentelemetry/contrib-test-utils": "^0.39.0",
         "@opentelemetry/instrumentation-http": "^0.44.0",
         "@opentelemetry/sdk-trace-base": "^1.24.1",
         "@types/express": "4.17.8",

--- a/packages/instrumentation-express/package.json
+++ b/packages/instrumentation-express/package.json
@@ -32,20 +32,20 @@
         "access": "public"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.6.0"
+        "@opentelemetry/api": "^1.8.0"
     },
     "dependencies": {
-        "@opentelemetry/core": "^1.17.1",
-        "@opentelemetry/instrumentation": "^0.44.0",
-        "@opentelemetry/semantic-conventions": "^1.17.1",
+        "@opentelemetry/core": "^1.24.1",
+        "@opentelemetry/instrumentation": "^0.51.1",
+        "@opentelemetry/semantic-conventions": "^1.24.1",
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.6.0",
+        "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.34.2",
         "@opentelemetry/instrumentation-http": "^0.44.0",
-        "@opentelemetry/sdk-trace-base": "^1.17.1",
+        "@opentelemetry/sdk-trace-base": "^1.24.1",
         "@types/express": "4.17.8",
         "@types/mocha": "^8.2.2",
         "axios": "0.21.1",

--- a/packages/instrumentation-express/src/express.ts
+++ b/packages/instrumentation-express/src/express.ts
@@ -31,7 +31,7 @@ import {
 } from './utils/attributes';
 import { consumeLayerPathAndUpdateState, createInitialRouteState } from './utils/route-context';
 import { getLayerPathFromFirstArg } from './utils/layer-path';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_HTTP_ROUTE, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 
 const originalLayerStore = Symbol('otel.express-plugins.orig-layer-export');
 
@@ -226,7 +226,7 @@ export class ExpressInstrumentation extends InstrumentationBase {
             res.end = function () {
                 const routeState = plugin.getCurrentRouteState(req);
                 const routeAttributes = getRouteAttributes(routeState);
-                const route = routeAttributes[SemanticAttributes.HTTP_ROUTE] as string;
+                const route = routeAttributes[SEMATTRS_HTTP_ROUTE] as string;
                 if (route) {
                     const rpcMetadata = getRPCMetadata(context.active());
                     if (rpcMetadata) {

--- a/packages/instrumentation-express/src/express.ts
+++ b/packages/instrumentation-express/src/express.ts
@@ -35,7 +35,7 @@ import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 
 const originalLayerStore = Symbol('otel.express-plugins.orig-layer-export');
 
-export class ExpressInstrumentation extends InstrumentationBase<typeof express> {
+export class ExpressInstrumentation extends InstrumentationBase {
     static readonly supportedVersions = ['^4.9.0'];
     protected override _config: ExpressInstrumentationConfig;
 
@@ -47,15 +47,15 @@ export class ExpressInstrumentation extends InstrumentationBase<typeof express> 
         this._config = Object.assign({}, config);
     }
 
-    protected init(): InstrumentationModuleDefinition<typeof express> {
-        const layerModule = new InstrumentationNodeModuleFile<ExpressLayer>(
+    protected init(): InstrumentationModuleDefinition {
+        const layerModule = new InstrumentationNodeModuleFile(
             'express/lib/router/layer.js',
             ExpressInstrumentation.supportedVersions,
             this._patchExpressLayer.bind(this),
             this._unpatchExpressLayer.bind(this)
         );
 
-        const module = new InstrumentationNodeModuleDefinition<typeof express>(
+        const module = new InstrumentationNodeModuleDefinition(
             'express',
             ExpressInstrumentation.supportedVersions,
             this.patch.bind(this),

--- a/packages/instrumentation-express/src/utils/attributes.ts
+++ b/packages/instrumentation-express/src/utils/attributes.ts
@@ -1,5 +1,5 @@
 import { SpanAttributes, SpanStatus, SpanStatusCode } from '@opentelemetry/api';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_HTTP_FLAVOR, SEMATTRS_HTTP_HOST, SEMATTRS_HTTP_METHOD, SEMATTRS_HTTP_ROUTE, SEMATTRS_HTTP_SCHEME, SEMATTRS_HTTP_STATUS_CODE, SEMATTRS_HTTP_TARGET, SEMATTRS_NET_PEER_IP, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { ExpressConsumedRouteState, ExpressInstrumentationAttributes } from '../types';
 import type express from 'express';
 
@@ -8,7 +8,7 @@ export const getRouteAttributes = (routeState: ExpressConsumedRouteState): SpanA
 
     const resolvedRoute = getResolvedRoute(routeState);
     if (resolvedRoute != null) {
-        attributes[SemanticAttributes.HTTP_ROUTE] = resolvedRoute;
+        attributes[SEMATTRS_HTTP_ROUTE] = resolvedRoute;
     }
 
     const fullRoute = getFullRoute(routeState);
@@ -55,7 +55,7 @@ export const getResolvedRoute = (expressRoutContext: ExpressConsumedRouteState):
 
 export const getHttpSpanAttributeFromRes = (res: express.Response): SpanAttributes => {
     return {
-        [SemanticAttributes.HTTP_STATUS_CODE]: res.statusCode,
+        [SEMATTRS_HTTP_STATUS_CODE]: res.statusCode,
     };
 };
 
@@ -83,12 +83,12 @@ export const createHostAttribute = (req: express.Request): string => {
 
 export const getHttpSpanAttributesFromReq = (req: express.Request): SpanAttributes => {
     return {
-        [SemanticAttributes.HTTP_METHOD]: req.method.toUpperCase(),
-        [SemanticAttributes.HTTP_TARGET]: req.originalUrl,
-        [SemanticAttributes.HTTP_FLAVOR]: req.httpVersion,
-        [SemanticAttributes.HTTP_HOST]: createHostAttribute(req),
-        [SemanticAttributes.HTTP_SCHEME]: req.protocol,
-        [SemanticAttributes.NET_PEER_IP]: req.ip,
+        [SEMATTRS_HTTP_METHOD]: req.method.toUpperCase(),
+        [SEMATTRS_HTTP_TARGET]: req.originalUrl,
+        [SEMATTRS_HTTP_FLAVOR]: req.httpVersion,
+        [SEMATTRS_HTTP_HOST]: createHostAttribute(req),
+        [SEMATTRS_HTTP_SCHEME]: req.protocol,
+        [SEMATTRS_NET_PEER_IP]: req.ip,
     };
 };
 

--- a/packages/instrumentation-express/src/utils/attributes.ts
+++ b/packages/instrumentation-express/src/utils/attributes.ts
@@ -1,5 +1,15 @@
 import { SpanAttributes, SpanStatus, SpanStatusCode } from '@opentelemetry/api';
-import { SEMATTRS_HTTP_FLAVOR, SEMATTRS_HTTP_HOST, SEMATTRS_HTTP_METHOD, SEMATTRS_HTTP_ROUTE, SEMATTRS_HTTP_SCHEME, SEMATTRS_HTTP_STATUS_CODE, SEMATTRS_HTTP_TARGET, SEMATTRS_NET_PEER_IP, SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+    SEMATTRS_HTTP_FLAVOR,
+    SEMATTRS_HTTP_HOST,
+    SEMATTRS_HTTP_METHOD,
+    SEMATTRS_HTTP_ROUTE,
+    SEMATTRS_HTTP_SCHEME,
+    SEMATTRS_HTTP_STATUS_CODE,
+    SEMATTRS_HTTP_TARGET,
+    SEMATTRS_NET_PEER_IP,
+    SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import { ExpressConsumedRouteState, ExpressInstrumentationAttributes } from '../types';
 import type express from 'express';
 

--- a/packages/instrumentation-express/src/utils/layer-path.ts
+++ b/packages/instrumentation-express/src/utils/layer-path.ts
@@ -37,8 +37,8 @@ const getLayerPathAlternativeFromFirstArg = (
                 typeof alternativePath === 'string'
                     ? pathStringToDisplayValue(alternativePath, options)
                     : alternativePath instanceof RegExp
-                    ? alternativePath.toString()
-                    : undefined,
+                      ? alternativePath.toString()
+                      : undefined,
             regexp: pathRegexp(alternativePath, [], options),
         }));
     }

--- a/packages/instrumentation-express/test/opentelemetry-express.spec.ts
+++ b/packages/instrumentation-express/test/opentelemetry-express.spec.ts
@@ -4,7 +4,7 @@ import { SpanKind, trace } from '@opentelemetry/api';
 import { ExpressInstrumentation } from '../src';
 import { AddressInfo } from 'net';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_HTTP_FLAVOR, SEMATTRS_HTTP_HOST, SEMATTRS_HTTP_METHOD, SEMATTRS_HTTP_ROUTE, SEMATTRS_HTTP_SCHEME, SEMATTRS_HTTP_STATUS_CODE, SEMATTRS_HTTP_TARGET, SEMATTRS_NET_PEER_IP } from '@opentelemetry/semantic-conventions';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { getTestSpans, registerInstrumentationTesting } from '@opentelemetry/contrib-test-utils';
 import * as bodyParser from 'body-parser';
@@ -74,19 +74,19 @@ describe('opentelemetry-express', () => {
                 expect(span.name).toBe('POST /toto/:id');
 
                 // HTTP Attributes
-                expect(span.attributes[SemanticAttributes.HTTP_METHOD]).toBeUndefined();
-                expect(span.attributes[SemanticAttributes.HTTP_TARGET]).toBeUndefined();
-                expect(span.attributes[SemanticAttributes.HTTP_SCHEME]).toBeUndefined();
-                expect(span.attributes[SemanticAttributes.HTTP_STATUS_CODE]).toBeUndefined();
-                expect(span.attributes[SemanticAttributes.HTTP_HOST]).toBeUndefined();
-                expect(span.attributes[SemanticAttributes.HTTP_FLAVOR]).toBeUndefined();
-                expect(span.attributes[SemanticAttributes.NET_PEER_IP]).toBeUndefined();
+                expect(span.attributes[SEMATTRS_HTTP_METHOD]).toBeUndefined();
+                expect(span.attributes[SEMATTRS_HTTP_TARGET]).toBeUndefined();
+                expect(span.attributes[SEMATTRS_HTTP_SCHEME]).toBeUndefined();
+                expect(span.attributes[SEMATTRS_HTTP_STATUS_CODE]).toBeUndefined();
+                expect(span.attributes[SEMATTRS_HTTP_HOST]).toBeUndefined();
+                expect(span.attributes[SEMATTRS_HTTP_FLAVOR]).toBeUndefined();
+                expect(span.attributes[SEMATTRS_NET_PEER_IP]).toBeUndefined();
 
                 // http span route
                 const [incomingHttpSpan] = getTestSpans().filter(
                     (s) => s.kind === SpanKind.SERVER && s.instrumentationLibrary.name.includes('http')
                 );
-                expect(incomingHttpSpan.attributes[SemanticAttributes.HTTP_ROUTE]).toMatch('/toto/:id');
+                expect(incomingHttpSpan.attributes[SEMATTRS_HTTP_ROUTE]).toMatch('/toto/:id');
                 done();
             } catch (error) {
                 done(error);
@@ -131,15 +131,15 @@ describe('opentelemetry-express', () => {
             const span: ReadableSpan = expressSpans[0];
 
             // HTTP Attributes
-            expect(span.attributes[SemanticAttributes.HTTP_METHOD]).toBe('POST');
-            expect(span.attributes[SemanticAttributes.HTTP_TARGET]).toBe(
+            expect(span.attributes[SEMATTRS_HTTP_METHOD]).toBe('POST');
+            expect(span.attributes[SEMATTRS_HTTP_TARGET]).toBe(
                 '/toto/tata?req-query-param-key=req-query-param-val'
             );
-            expect(span.attributes[SemanticAttributes.HTTP_SCHEME]).toBe('http');
-            expect(span.attributes[SemanticAttributes.HTTP_STATUS_CODE]).toBe(200);
-            expect(span.attributes[SemanticAttributes.HTTP_HOST]).toBe(`localhost:${port}`);
-            expect(span.attributes[SemanticAttributes.HTTP_FLAVOR]).toBe('1.1');
-            expect(span.attributes[SemanticAttributes.NET_PEER_IP]).toBe('::ffff:127.0.0.1');
+            expect(span.attributes[SEMATTRS_HTTP_SCHEME]).toBe('http');
+            expect(span.attributes[SEMATTRS_HTTP_STATUS_CODE]).toBe(200);
+            expect(span.attributes[SEMATTRS_HTTP_HOST]).toBe(`localhost:${port}`);
+            expect(span.attributes[SEMATTRS_HTTP_FLAVOR]).toBe('1.1');
+            expect(span.attributes[SEMATTRS_NET_PEER_IP]).toBe('::ffff:127.0.0.1');
 
             server.close();
             done();

--- a/packages/instrumentation-express/test/opentelemetry-express.spec.ts
+++ b/packages/instrumentation-express/test/opentelemetry-express.spec.ts
@@ -4,7 +4,16 @@ import { SpanKind, trace } from '@opentelemetry/api';
 import { ExpressInstrumentation } from '../src';
 import { AddressInfo } from 'net';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import { SEMATTRS_HTTP_FLAVOR, SEMATTRS_HTTP_HOST, SEMATTRS_HTTP_METHOD, SEMATTRS_HTTP_ROUTE, SEMATTRS_HTTP_SCHEME, SEMATTRS_HTTP_STATUS_CODE, SEMATTRS_HTTP_TARGET, SEMATTRS_NET_PEER_IP } from '@opentelemetry/semantic-conventions';
+import {
+    SEMATTRS_HTTP_FLAVOR,
+    SEMATTRS_HTTP_HOST,
+    SEMATTRS_HTTP_METHOD,
+    SEMATTRS_HTTP_ROUTE,
+    SEMATTRS_HTTP_SCHEME,
+    SEMATTRS_HTTP_STATUS_CODE,
+    SEMATTRS_HTTP_TARGET,
+    SEMATTRS_NET_PEER_IP,
+} from '@opentelemetry/semantic-conventions';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { getTestSpans, registerInstrumentationTesting } from '@opentelemetry/contrib-test-utils';
 import * as bodyParser from 'body-parser';
@@ -132,9 +141,7 @@ describe('opentelemetry-express', () => {
 
             // HTTP Attributes
             expect(span.attributes[SEMATTRS_HTTP_METHOD]).toBe('POST');
-            expect(span.attributes[SEMATTRS_HTTP_TARGET]).toBe(
-                '/toto/tata?req-query-param-key=req-query-param-val'
-            );
+            expect(span.attributes[SEMATTRS_HTTP_TARGET]).toBe('/toto/tata?req-query-param-key=req-query-param-val');
             expect(span.attributes[SEMATTRS_HTTP_SCHEME]).toBe('http');
             expect(span.attributes[SEMATTRS_HTTP_STATUS_CODE]).toBe(200);
             expect(span.attributes[SEMATTRS_HTTP_HOST]).toBe(`localhost:${port}`);

--- a/packages/instrumentation-express/test/utils.ts
+++ b/packages/instrumentation-express/test/utils.ts
@@ -1,4 +1,4 @@
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_HTTP_ROUTE, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import expect from 'expect';
 import { ExpressInstrumentationAttributes } from '../src/types';
@@ -17,7 +17,7 @@ export const expectRouteAttributes = (
     options?: expectRouteAttributesAdvancedOptions
 ) => {
     const { expectedParams, configuredRoute } = options ?? {};
-    expect(span.attributes[SemanticAttributes.HTTP_ROUTE]).toEqual(expectedRoute);
+    expect(span.attributes[SEMATTRS_HTTP_ROUTE]).toEqual(expectedRoute);
     expect(span.attributes[ExpressInstrumentationAttributes.EXPRESS_ROUTE_FULL]).toEqual(expectedFullRoute);
     const actualParams = JSON.parse(span.attributes[ExpressInstrumentationAttributes.EXPRESS_ROUTE_PARAMS] as string);
     expect(actualParams).toStrictEqual(expectedParams ?? {});
@@ -29,7 +29,7 @@ export const expectRouteAttributes = (
 };
 
 export const expectRouteFromFinalHandler = (span: ReadableSpan, fullRoute: string) => {
-    expect(span.attributes[SemanticAttributes.HTTP_ROUTE]).toEqual('');
+    expect(span.attributes[SEMATTRS_HTTP_ROUTE]).toEqual('');
     // we need to patch final handler to extract the full url
     expect(span.attributes[ExpressInstrumentationAttributes.EXPRESS_ROUTE_FULL]).toEqual(fullRoute);
     expect(span.attributes[ExpressInstrumentationAttributes.EXPRESS_UNHANDLED]).toEqual(true);

--- a/packages/instrumentation-kafkajs/package.json
+++ b/packages/instrumentation-kafkajs/package.json
@@ -51,7 +51,7 @@
         "mocha": "^8.4.0",
         "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "ts-node": "^9.1.1",
-        "typescript": "4.3.4"
+        "typescript": "5.4.5"
     },
     "mocha": {
         "extension": [

--- a/packages/instrumentation-kafkajs/package.json
+++ b/packages/instrumentation-kafkajs/package.json
@@ -50,7 +50,7 @@
         "kafkajs": "^1.16.0",
         "mocha": "^8.4.0",
         "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
-        "ts-node": "^9.1.1",
+        "ts-node": "^10.9.2",
         "typescript": "5.4.5"
     },
     "mocha": {

--- a/packages/instrumentation-kafkajs/package.json
+++ b/packages/instrumentation-kafkajs/package.json
@@ -43,7 +43,7 @@
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.8.0",
-        "@opentelemetry/contrib-test-utils": "^0.34.2",
+        "@opentelemetry/contrib-test-utils": "^0.39.0",
         "@opentelemetry/sdk-trace-base": "^1.24.1",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",

--- a/packages/instrumentation-kafkajs/package.json
+++ b/packages/instrumentation-kafkajs/package.json
@@ -35,16 +35,16 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.6.0"
+        "@opentelemetry/api": "^1.8.0"
     },
     "dependencies": {
-        "@opentelemetry/instrumentation": "^0.44.0",
-        "@opentelemetry/semantic-conventions": "^1.17.1"
+        "@opentelemetry/instrumentation": "^0.51.1",
+        "@opentelemetry/semantic-conventions": "^1.24.1"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.34.2",
-        "@opentelemetry/sdk-trace-base": "^1.17.1",
+        "@opentelemetry/sdk-trace-base": "^1.24.1",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "kafkajs": "^1.16.0",

--- a/packages/instrumentation-kafkajs/package.json
+++ b/packages/instrumentation-kafkajs/package.json
@@ -49,7 +49,7 @@
         "expect": "^26.6.2",
         "kafkajs": "^1.16.0",
         "mocha": "^8.4.0",
-        "opentelemetry-instrumentation-mocha": "0.0.7-alpha.1",
+        "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "ts-node": "^9.1.1",
         "typescript": "4.3.4"
     },
@@ -60,7 +60,7 @@
         "spec": "test/**/*.spec.ts",
         "require": [
             "ts-node/register",
-            "opentelemetry-instrumentation-mocha"
+            "aspecto-opentelemetry-instrumentation-mocha"
         ]
     }
 }

--- a/packages/instrumentation-kafkajs/src/kafkajs.ts
+++ b/packages/instrumentation-kafkajs/src/kafkajs.ts
@@ -14,6 +14,10 @@ import {
     SemanticAttributes,
     MessagingOperationValues,
     MessagingDestinationKindValues,
+    SEMATTRS_MESSAGING_SYSTEM,
+    SEMATTRS_MESSAGING_DESTINATION_KIND,
+    SEMATTRS_MESSAGING_DESTINATION,
+    SEMATTRS_MESSAGING_OPERATION,
 } from '@opentelemetry/semantic-conventions';
 import * as kafkaJs from 'kafkajs';
 import {
@@ -250,10 +254,10 @@ export class KafkaJsInstrumentation extends InstrumentationBase {
             {
                 kind: SpanKind.CONSUMER,
                 attributes: {
-                    [SemanticAttributes.MESSAGING_SYSTEM]: 'kafka',
-                    [SemanticAttributes.MESSAGING_DESTINATION]: topic,
-                    [SemanticAttributes.MESSAGING_DESTINATION_KIND]: MessagingDestinationKindValues.TOPIC,
-                    [SemanticAttributes.MESSAGING_OPERATION]: operation,
+                    [SEMATTRS_MESSAGING_SYSTEM]: 'kafka',
+                    [SEMATTRS_MESSAGING_DESTINATION]: topic,
+                    [SEMATTRS_MESSAGING_DESTINATION_KIND]: MessagingDestinationKindValues.TOPIC,
+                    [SEMATTRS_MESSAGING_OPERATION]: operation,
                 },
                 links: link ? [link] : [],
             },
@@ -281,9 +285,9 @@ export class KafkaJsInstrumentation extends InstrumentationBase {
         const span = this.tracer.startSpan(topic, {
             kind: SpanKind.PRODUCER,
             attributes: {
-                [SemanticAttributes.MESSAGING_SYSTEM]: 'kafka',
-                [SemanticAttributes.MESSAGING_DESTINATION]: topic,
-                [SemanticAttributes.MESSAGING_DESTINATION_KIND]: MessagingDestinationKindValues.TOPIC,
+                [SEMATTRS_MESSAGING_SYSTEM]: 'kafka',
+                [SEMATTRS_MESSAGING_DESTINATION]: topic,
+                [SEMATTRS_MESSAGING_DESTINATION_KIND]: MessagingDestinationKindValues.TOPIC,
             },
         });
 

--- a/packages/instrumentation-kafkajs/src/kafkajs.ts
+++ b/packages/instrumentation-kafkajs/src/kafkajs.ts
@@ -39,7 +39,7 @@ import {
     isWrapped,
 } from '@opentelemetry/instrumentation';
 
-export class KafkaJsInstrumentation extends InstrumentationBase<typeof kafkaJs> {
+export class KafkaJsInstrumentation extends InstrumentationBase {
     static readonly component = 'kafkajs';
     protected override _config!: KafkaJsInstrumentationConfig;
     private moduleVersion: string;
@@ -52,10 +52,8 @@ export class KafkaJsInstrumentation extends InstrumentationBase<typeof kafkaJs> 
         this._config = Object.assign({}, config);
     }
 
-    protected init(): InstrumentationModuleDefinition<typeof kafkaJs> {
-        const module: InstrumentationModuleDefinition<typeof kafkaJs> = new InstrumentationNodeModuleDefinition<
-            typeof kafkaJs
-        >(KafkaJsInstrumentation.component, ['*'], this.patch.bind(this), this.unpatch.bind(this));
+    protected init(): InstrumentationModuleDefinition {
+        const module: InstrumentationModuleDefinition = new InstrumentationNodeModuleDefinition(KafkaJsInstrumentation.component, ['*'], this.patch.bind(this), this.unpatch.bind(this));
         module.includePrerelease = true;
         return module;
     }

--- a/packages/instrumentation-kafkajs/src/kafkajs.ts
+++ b/packages/instrumentation-kafkajs/src/kafkajs.ts
@@ -53,7 +53,12 @@ export class KafkaJsInstrumentation extends InstrumentationBase {
     }
 
     protected init(): InstrumentationModuleDefinition {
-        const module: InstrumentationModuleDefinition = new InstrumentationNodeModuleDefinition(KafkaJsInstrumentation.component, ['*'], this.patch.bind(this), this.unpatch.bind(this));
+        const module: InstrumentationModuleDefinition = new InstrumentationNodeModuleDefinition(
+            KafkaJsInstrumentation.component,
+            ['*'],
+            this.patch.bind(this),
+            this.unpatch.bind(this)
+        );
         module.includePrerelease = true;
         return module;
     }

--- a/packages/instrumentation-kafkajs/test/kafkajs.spec.ts
+++ b/packages/instrumentation-kafkajs/test/kafkajs.spec.ts
@@ -3,7 +3,14 @@ import expect from 'expect';
 import { KafkaJsInstrumentation, KafkaJsInstrumentationConfig } from '../src';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { propagation, context, SpanKind, SpanStatusCode, Span } from '@opentelemetry/api';
-import { MessagingDestinationKindValues, SEMATTRS_MESSAGING_DESTINATION, SEMATTRS_MESSAGING_DESTINATION_KIND, SEMATTRS_MESSAGING_OPERATION, SEMATTRS_MESSAGING_SYSTEM, SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+    MessagingDestinationKindValues,
+    SEMATTRS_MESSAGING_DESTINATION,
+    SEMATTRS_MESSAGING_DESTINATION_KIND,
+    SEMATTRS_MESSAGING_OPERATION,
+    SEMATTRS_MESSAGING_SYSTEM,
+    SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import { getTestSpans, registerInstrumentationTesting } from '@opentelemetry/contrib-test-utils';
 
 const instrumentation = registerInstrumentationTesting(new KafkaJsInstrumentation());

--- a/packages/instrumentation-kafkajs/test/kafkajs.spec.ts
+++ b/packages/instrumentation-kafkajs/test/kafkajs.spec.ts
@@ -3,7 +3,7 @@ import expect from 'expect';
 import { KafkaJsInstrumentation, KafkaJsInstrumentationConfig } from '../src';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { propagation, context, SpanKind, SpanStatusCode, Span } from '@opentelemetry/api';
-import { MessagingDestinationKindValues, SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { MessagingDestinationKindValues, SEMATTRS_MESSAGING_DESTINATION, SEMATTRS_MESSAGING_DESTINATION_KIND, SEMATTRS_MESSAGING_OPERATION, SEMATTRS_MESSAGING_SYSTEM, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { getTestSpans, registerInstrumentationTesting } from '@opentelemetry/contrib-test-utils';
 
 const instrumentation = registerInstrumentationTesting(new KafkaJsInstrumentation());
@@ -119,11 +119,11 @@ describe('instrumentation-kafkajs', () => {
                 expect(span.kind).toStrictEqual(SpanKind.PRODUCER);
                 expect(span.name).toStrictEqual('topic-name-1');
                 expect(span.status.code).toStrictEqual(SpanStatusCode.UNSET);
-                expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toStrictEqual('kafka');
-                expect(span.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toStrictEqual(
+                expect(span.attributes[SEMATTRS_MESSAGING_SYSTEM]).toStrictEqual('kafka');
+                expect(span.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]).toStrictEqual(
                     MessagingDestinationKindValues.TOPIC
                 );
-                expect(span.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toStrictEqual('topic-name-1');
+                expect(span.attributes[SEMATTRS_MESSAGING_DESTINATION]).toStrictEqual('topic-name-1');
 
                 expect(messagesSent.length).toBe(1);
                 expectKafkaHeadersToMatchSpanContext(messagesSent[0], span as ReadableSpan);
@@ -426,12 +426,12 @@ describe('instrumentation-kafkajs', () => {
                 expect(span.parentSpanId).toBeUndefined();
                 expect(span.kind).toStrictEqual(SpanKind.CONSUMER);
                 expect(span.status.code).toStrictEqual(SpanStatusCode.UNSET);
-                expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toStrictEqual('kafka');
-                expect(span.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toStrictEqual(
+                expect(span.attributes[SEMATTRS_MESSAGING_SYSTEM]).toStrictEqual('kafka');
+                expect(span.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]).toStrictEqual(
                     MessagingDestinationKindValues.TOPIC
                 );
-                expect(span.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toStrictEqual('topic-name-1');
-                expect(span.attributes[SemanticAttributes.MESSAGING_OPERATION]).toStrictEqual('process');
+                expect(span.attributes[SEMATTRS_MESSAGING_DESTINATION]).toStrictEqual('topic-name-1');
+                expect(span.attributes[SEMATTRS_MESSAGING_OPERATION]).toStrictEqual('process');
             });
 
             it('consumer eachMessage with non promise return value', async () => {
@@ -611,23 +611,23 @@ describe('instrumentation-kafkajs', () => {
                 spans.forEach((span) => {
                     expect(span.name).toStrictEqual('topic-name-1');
                     expect(span.status.code).toStrictEqual(SpanStatusCode.UNSET);
-                    expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toStrictEqual('kafka');
-                    expect(span.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]).toStrictEqual(
+                    expect(span.attributes[SEMATTRS_MESSAGING_SYSTEM]).toStrictEqual('kafka');
+                    expect(span.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]).toStrictEqual(
                         MessagingDestinationKindValues.TOPIC
                     );
-                    expect(span.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toStrictEqual('topic-name-1');
+                    expect(span.attributes[SEMATTRS_MESSAGING_DESTINATION]).toStrictEqual('topic-name-1');
                 });
 
                 const [recvSpan, msg1Span, msg2Span] = spans;
 
                 expect(recvSpan.parentSpanId).toBeUndefined();
-                expect(recvSpan.attributes[SemanticAttributes.MESSAGING_OPERATION]).toStrictEqual('receive');
+                expect(recvSpan.attributes[SEMATTRS_MESSAGING_OPERATION]).toStrictEqual('receive');
 
                 expect(msg1Span.parentSpanId).toStrictEqual(recvSpan.spanContext().spanId);
-                expect(msg1Span.attributes[SemanticAttributes.MESSAGING_OPERATION]).toStrictEqual('process');
+                expect(msg1Span.attributes[SEMATTRS_MESSAGING_OPERATION]).toStrictEqual('process');
 
                 expect(msg2Span.parentSpanId).toStrictEqual(recvSpan.spanContext().spanId);
-                expect(msg2Span.attributes[SemanticAttributes.MESSAGING_OPERATION]).toStrictEqual('process');
+                expect(msg2Span.attributes[SEMATTRS_MESSAGING_OPERATION]).toStrictEqual('process');
             });
 
             it('consumer eachBatch with non promise return value', async () => {

--- a/packages/instrumentation-neo4j/package.json
+++ b/packages/instrumentation-neo4j/package.json
@@ -41,16 +41,16 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.6.0"
+        "@opentelemetry/api": "^1.8.0"
     },
     "dependencies": {
-        "@opentelemetry/instrumentation": "^0.44.0",
-        "@opentelemetry/semantic-conventions": "^1.17.1"
+        "@opentelemetry/instrumentation": "^0.51.1",
+        "@opentelemetry/semantic-conventions": "^1.24.1"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.6.0",
+        "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.34.2",
-        "@opentelemetry/sdk-trace-base": "^1.17.1",
+        "@opentelemetry/sdk-trace-base": "^1.24.1",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/packages/instrumentation-neo4j/package.json
+++ b/packages/instrumentation-neo4j/package.json
@@ -49,7 +49,7 @@
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.8.0",
-        "@opentelemetry/contrib-test-utils": "^0.34.2",
+        "@opentelemetry/contrib-test-utils": "^0.39.0",
         "@opentelemetry/sdk-trace-base": "^1.24.1",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",

--- a/packages/instrumentation-neo4j/package.json
+++ b/packages/instrumentation-neo4j/package.json
@@ -55,7 +55,7 @@
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
         "neo4j-driver": "^4.2.2",
-        "opentelemetry-instrumentation-mocha": "0.0.7-alpha.1",
+        "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "test-all-versions": "^5.0.1",
         "ts-node": "^9.1.1",
         "typescript": "4.3.4"
@@ -67,7 +67,7 @@
         "spec": "test/**/*.spec.ts",
         "require": [
             "ts-node/register",
-            "opentelemetry-instrumentation-mocha"
+            "aspecto-opentelemetry-instrumentation-mocha"
         ]
     }
 }

--- a/packages/instrumentation-neo4j/package.json
+++ b/packages/instrumentation-neo4j/package.json
@@ -57,7 +57,7 @@
         "neo4j-driver": "^4.2.2",
         "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "test-all-versions": "^5.0.1",
-        "ts-node": "^9.1.1",
+        "ts-node": "^10.9.2",
         "typescript": "5.4.5"
     },
     "mocha": {

--- a/packages/instrumentation-neo4j/package.json
+++ b/packages/instrumentation-neo4j/package.json
@@ -58,7 +58,7 @@
         "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "test-all-versions": "^5.0.1",
         "ts-node": "^9.1.1",
-        "typescript": "4.3.4"
+        "typescript": "5.4.5"
     },
     "mocha": {
         "extension": [

--- a/packages/instrumentation-neo4j/src/neo4j.ts
+++ b/packages/instrumentation-neo4j/src/neo4j.ts
@@ -4,7 +4,6 @@ import {
     SEMATTRS_DB_OPERATION,
     SEMATTRS_DB_STATEMENT,
     SEMATTRS_DB_SYSTEM,
-    SemanticAttributes,
 } from '@opentelemetry/semantic-conventions';
 import { VERSION } from './version';
 import type * as neo4j from 'neo4j-driver';

--- a/packages/instrumentation-neo4j/src/neo4j.ts
+++ b/packages/instrumentation-neo4j/src/neo4j.ts
@@ -1,5 +1,11 @@
 import { SpanStatusCode, diag, trace, context, SpanKind } from '@opentelemetry/api';
-import { SEMATTRS_DB_NAME, SEMATTRS_DB_OPERATION, SEMATTRS_DB_STATEMENT, SEMATTRS_DB_SYSTEM, SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+    SEMATTRS_DB_NAME,
+    SEMATTRS_DB_OPERATION,
+    SEMATTRS_DB_STATEMENT,
+    SEMATTRS_DB_SYSTEM,
+    SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import { VERSION } from './version';
 import type * as neo4j from 'neo4j-driver';
 import {

--- a/packages/instrumentation-neo4j/src/neo4j.ts
+++ b/packages/instrumentation-neo4j/src/neo4j.ts
@@ -1,5 +1,5 @@
 import { SpanStatusCode, diag, trace, context, SpanKind } from '@opentelemetry/api';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_DB_NAME, SEMATTRS_DB_OPERATION, SEMATTRS_DB_STATEMENT, SEMATTRS_DB_SYSTEM, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { VERSION } from './version';
 import type * as neo4j from 'neo4j-driver';
 import {
@@ -67,12 +67,12 @@ export class Neo4jInstrumentation extends InstrumentationBase {
 
                 const connectionAttributes = getAttributesFromNeo4jSession(this);
                 const operation = query.trim().split(/\s+/)[0];
-                const span = self.tracer.startSpan(`${operation} ${connectionAttributes[SemanticAttributes.DB_NAME]}`, {
+                const span = self.tracer.startSpan(`${operation} ${connectionAttributes[SEMATTRS_DB_NAME]}`, {
                     attributes: {
                         ...connectionAttributes,
-                        [SemanticAttributes.DB_SYSTEM]: 'neo4j',
-                        [SemanticAttributes.DB_OPERATION]: operation,
-                        [SemanticAttributes.DB_STATEMENT]: query,
+                        [SEMATTRS_DB_SYSTEM]: 'neo4j',
+                        [SEMATTRS_DB_OPERATION]: operation,
+                        [SEMATTRS_DB_STATEMENT]: query,
                     },
                     kind: SpanKind.CLIENT,
                 });

--- a/packages/instrumentation-neo4j/src/neo4j.ts
+++ b/packages/instrumentation-neo4j/src/neo4j.ts
@@ -14,7 +14,7 @@ import { getAttributesFromNeo4jSession } from './utils';
 
 type Neo4J = typeof neo4j;
 
-export class Neo4jInstrumentation extends InstrumentationBase<Neo4J> {
+export class Neo4jInstrumentation extends InstrumentationBase {
     protected override _config!: Neo4jInstrumentationConfig;
 
     constructor(config: Neo4jInstrumentationConfig = {}) {
@@ -25,17 +25,17 @@ export class Neo4jInstrumentation extends InstrumentationBase<Neo4J> {
         this._config = config;
     }
 
-    protected init(): InstrumentationModuleDefinition<Neo4J>[] {
+    protected init(): InstrumentationModuleDefinition[] {
         return [
             this.getModuleDefinition('neo4j-driver-core', ['>=4.3.0 <5']),
             this.getModuleDefinition('neo4j-driver', ['>=4.0.0 <4.3.0']),
         ];
     }
 
-    private getModuleDefinition(name: string, supportedVersions: string[]): InstrumentationNodeModuleDefinition<Neo4J> {
+    private getModuleDefinition(name: string, supportedVersions: string[]): InstrumentationNodeModuleDefinition {
         const apiModuleFiles = ['session', 'transaction'].map(
             (file) =>
-                new InstrumentationNodeModuleFile<neo4j.Session>(
+                new InstrumentationNodeModuleFile(
                     `${name}/lib/${file}.js`,
                     supportedVersions,
                     this.patchSessionOrTransaction.bind(this),
@@ -43,7 +43,7 @@ export class Neo4jInstrumentation extends InstrumentationBase<Neo4J> {
                 )
         );
 
-        const module = new InstrumentationNodeModuleDefinition<Neo4J>(
+        const module = new InstrumentationNodeModuleDefinition(
             name,
             supportedVersions,
             undefined,

--- a/packages/instrumentation-neo4j/src/utils.ts
+++ b/packages/instrumentation-neo4j/src/utils.ts
@@ -1,4 +1,4 @@
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_DB_NAME, SEMATTRS_DB_USER, SEMATTRS_NET_PEER_NAME, SEMATTRS_NET_PEER_PORT, SEMATTRS_NET_TRANSPORT, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 
 export function getAttributesFromNeo4jSession(session: any) {
     const connectionHolder =
@@ -12,16 +12,16 @@ export function getAttributesFromNeo4jSession(session: any) {
     const auth = connectionProvider._authToken;
 
     const attributes = {
-        [SemanticAttributes.NET_TRANSPORT]: 'IP.TCP',
+        [SEMATTRS_NET_TRANSPORT]: 'IP.TCP',
         // "neo4j" is the default database name. When used, "session._database" is an empty string
-        [SemanticAttributes.DB_NAME]: session._database ? session._database : 'neo4j',
+        [SEMATTRS_DB_NAME]: session._database ? session._database : 'neo4j',
     };
     if (address) {
-        attributes[SemanticAttributes.NET_PEER_NAME] = address._host;
-        attributes[SemanticAttributes.NET_PEER_PORT] = address._port;
+        attributes[SEMATTRS_NET_PEER_NAME] = address._host;
+        attributes[SEMATTRS_NET_PEER_PORT] = address._port;
     }
     if (auth?.principal) {
-        attributes[SemanticAttributes.DB_USER] = auth.principal;
+        attributes[SEMATTRS_DB_USER] = auth.principal;
     }
     return attributes;
 }

--- a/packages/instrumentation-neo4j/src/utils.ts
+++ b/packages/instrumentation-neo4j/src/utils.ts
@@ -1,4 +1,11 @@
-import { SEMATTRS_DB_NAME, SEMATTRS_DB_USER, SEMATTRS_NET_PEER_NAME, SEMATTRS_NET_PEER_PORT, SEMATTRS_NET_TRANSPORT, SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+    SEMATTRS_DB_NAME,
+    SEMATTRS_DB_USER,
+    SEMATTRS_NET_PEER_NAME,
+    SEMATTRS_NET_PEER_PORT,
+    SEMATTRS_NET_TRANSPORT,
+    SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 
 export function getAttributesFromNeo4jSession(session: any) {
     const connectionHolder =

--- a/packages/instrumentation-neo4j/test/assert.ts
+++ b/packages/instrumentation-neo4j/test/assert.ts
@@ -1,6 +1,13 @@
 import expect from 'expect';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import { SEMATTRS_DB_NAME, SEMATTRS_DB_SYSTEM, SEMATTRS_DB_USER, SEMATTRS_NET_PEER_NAME, SEMATTRS_NET_PEER_PORT, SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+    SEMATTRS_DB_NAME,
+    SEMATTRS_DB_SYSTEM,
+    SEMATTRS_DB_USER,
+    SEMATTRS_NET_PEER_NAME,
+    SEMATTRS_NET_PEER_PORT,
+    SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
 
 export const assertSpan = (span: ReadableSpan) => {

--- a/packages/instrumentation-neo4j/test/assert.ts
+++ b/packages/instrumentation-neo4j/test/assert.ts
@@ -1,15 +1,15 @@
 import expect from 'expect';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_DB_NAME, SEMATTRS_DB_SYSTEM, SEMATTRS_DB_USER, SEMATTRS_NET_PEER_NAME, SEMATTRS_NET_PEER_PORT, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
 
 export const assertSpan = (span: ReadableSpan) => {
     expect(span.kind).toBe(SpanKind.CLIENT);
     expect(span.status.code).toBe(SpanStatusCode.UNSET);
-    expect(span.attributes[SemanticAttributes.DB_SYSTEM]).toEqual('neo4j');
-    expect(span.attributes[SemanticAttributes.DB_NAME]).toEqual('neo4j');
-    expect(span.attributes[SemanticAttributes.DB_USER]).toEqual('neo4j');
-    expect(span.attributes[SemanticAttributes.NET_PEER_NAME]).toEqual('localhost');
-    expect(span.attributes[SemanticAttributes.NET_PEER_PORT]).toEqual(11011);
-    expect(span.attributes[SemanticAttributes.NET_TRANSPORT]).toEqual('IP.TCP');
+    expect(span.attributes[SEMATTRS_DB_SYSTEM]).toEqual('neo4j');
+    expect(span.attributes[SEMATTRS_DB_NAME]).toEqual('neo4j');
+    expect(span.attributes[SEMATTRS_DB_USER]).toEqual('neo4j');
+    expect(span.attributes[SEMATTRS_NET_PEER_NAME]).toEqual('localhost');
+    expect(span.attributes[SEMATTRS_NET_PEER_PORT]).toEqual(11011);
+    expect(span.attributes[SEMATTRS_NET_PEER_PORT]).toEqual('IP.TCP');
 };

--- a/packages/instrumentation-neo4j/test/assert.ts
+++ b/packages/instrumentation-neo4j/test/assert.ts
@@ -6,7 +6,7 @@ import {
     SEMATTRS_DB_USER,
     SEMATTRS_NET_PEER_NAME,
     SEMATTRS_NET_PEER_PORT,
-    SemanticAttributes,
+    SEMATTRS_NET_TRANSPORT,
 } from '@opentelemetry/semantic-conventions';
 import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
 
@@ -18,5 +18,5 @@ export const assertSpan = (span: ReadableSpan) => {
     expect(span.attributes[SEMATTRS_DB_USER]).toEqual('neo4j');
     expect(span.attributes[SEMATTRS_NET_PEER_NAME]).toEqual('localhost');
     expect(span.attributes[SEMATTRS_NET_PEER_PORT]).toEqual(11011);
-    expect(span.attributes[SEMATTRS_NET_PEER_PORT]).toEqual('IP.TCP');
+    expect(span.attributes[SEMATTRS_NET_TRANSPORT]).toEqual('IP.TCP');
 };

--- a/packages/instrumentation-neo4j/test/neo4j.spec.ts
+++ b/packages/instrumentation-neo4j/test/neo4j.spec.ts
@@ -20,7 +20,7 @@ import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
  * Tests require neo4j to run, and expose bolt port of 11011
  *
  * Use this command to run the required neo4j using docker:
- * docker run --name testneo4j -p7474:7474 -p11011:7687 -d --env NEO4J_AUTH=neo4j/test neo4j:4.2.3
+ * docker run --name testneo4j -p7474:7474 -p11011:7687 -d --env NEO4J_AUTH=neo4j/test neo4j:4.4.34
  * */
 
 describe('neo4j instrumentation', function () {
@@ -464,7 +464,7 @@ describe('neo4j instrumentation', function () {
 
         before(() => {
             if (shouldCheck) {
-                routingDriver = neo4j.driver('neo4j://localhost:11011', neo4j.auth.basic('neo4j', 'test'));
+                routingDriver = neo4j.driver('neo4j://localhost:11011', neo4j.auth.basic('neo4j', 'your_password'));
             }
         });
 

--- a/packages/instrumentation-neo4j/test/neo4j.spec.ts
+++ b/packages/instrumentation-neo4j/test/neo4j.spec.ts
@@ -3,7 +3,7 @@ import expect from 'expect';
 import { context, ROOT_CONTEXT, SpanStatusCode, trace } from '@opentelemetry/api';
 import { Neo4jInstrumentation } from '../src';
 import { assertSpan } from './assert';
-import { SemanticAttributes, SEMATTRS_DB_OPERATION, SEMATTRS_DB_STATEMENT } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_DB_OPERATION, SEMATTRS_DB_STATEMENT } from '@opentelemetry/semantic-conventions';
 import { normalizeResponse } from './test-utils';
 import { map, mergeMap } from 'rxjs/operators';
 import { concat } from 'rxjs';
@@ -34,7 +34,7 @@ describe('neo4j instrumentation', function () {
     };
 
     before(async () => {
-        driver = neo4j.driver('bolt://localhost:11011', neo4j.auth.basic('neo4j', 'test'), {
+        driver = neo4j.driver('bolt://localhost:11011', neo4j.auth.basic('neo4j', 'your_password'), {
             disableLosslessIntegers: true,
         });
 

--- a/packages/instrumentation-neo4j/test/neo4j.spec.ts
+++ b/packages/instrumentation-neo4j/test/neo4j.spec.ts
@@ -3,7 +3,7 @@ import expect from 'expect';
 import { context, ROOT_CONTEXT, SpanStatusCode, trace } from '@opentelemetry/api';
 import { Neo4jInstrumentation } from '../src';
 import { assertSpan } from './assert';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SemanticAttributes, SEMATTRS_DB_OPERATION, SEMATTRS_DB_STATEMENT } from '@opentelemetry/semantic-conventions';
 import { normalizeResponse } from './test-utils';
 import { map, mergeMap } from 'rxjs/operators';
 import { concat } from 'rxjs';
@@ -78,8 +78,8 @@ describe('neo4j instrumentation', function () {
             const span = getSingleSpan();
             assertSpan(span as ReadableSpan);
             expect(span.name).toBe('CREATE neo4j');
-            expect(span.attributes[SemanticAttributes.DB_OPERATION]).toBe('CREATE');
-            expect(span.attributes[SemanticAttributes.DB_STATEMENT]).toBe('CREATE (n:MyLabel) RETURN n');
+            expect(span.attributes[SEMATTRS_DB_OPERATION]).toBe('CREATE');
+            expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe('CREATE (n:MyLabel) RETURN n');
         });
 
         it('instruments "run" with subscribe', (done) => {
@@ -90,8 +90,8 @@ describe('neo4j instrumentation', function () {
                     onCompleted: () => {
                         const span = getSingleSpan();
                         assertSpan(span as ReadableSpan);
-                        expect(span.attributes[SemanticAttributes.DB_OPERATION]).toBe('CREATE');
-                        expect(span.attributes[SemanticAttributes.DB_STATEMENT]).toBe('CREATE (n:MyLabel) RETURN n');
+                        expect(span.attributes[SEMATTRS_DB_OPERATION]).toBe('CREATE');
+                        expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe('CREATE (n:MyLabel) RETURN n');
                         done();
                     },
                 });
@@ -169,14 +169,14 @@ describe('neo4j instrumentation', function () {
             expect(spans.length).toBe(3);
             for (let span of spans) {
                 assertSpan(span as ReadableSpan);
-                expect(span.attributes[SemanticAttributes.DB_OPERATION]).toBe('MATCH');
+                expect(span.attributes[SEMATTRS_DB_OPERATION]).toBe('MATCH');
             }
         });
 
         it('captures operation with trailing white spaces', async () => {
             await driver.session().run('  MATCH (k) RETURN k ');
             const span = getSingleSpan();
-            expect(span.attributes[SemanticAttributes.DB_OPERATION]).toBe('MATCH');
+            expect(span.attributes[SEMATTRS_DB_OPERATION]).toBe('MATCH');
         });
 
         it('set module versions when config is set', async () => {
@@ -288,8 +288,8 @@ describe('neo4j instrumentation', function () {
             });
             const span = getSingleSpan();
             assertSpan(span as ReadableSpan);
-            expect(span.attributes[SemanticAttributes.DB_OPERATION]).toBe('MATCH');
-            expect(span.attributes[SemanticAttributes.DB_STATEMENT]).toBe(
+            expect(span.attributes[SEMATTRS_DB_OPERATION]).toBe('MATCH');
+            expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe(
                 'MATCH (person:Person) RETURN person.name AS name'
             );
         });
@@ -300,8 +300,8 @@ describe('neo4j instrumentation', function () {
             });
             const span = getSingleSpan();
             assertSpan(span as ReadableSpan);
-            expect(span.attributes[SemanticAttributes.DB_OPERATION]).toBe('MATCH');
-            expect(span.attributes[SemanticAttributes.DB_STATEMENT]).toBe(
+            expect(span.attributes[SEMATTRS_DB_OPERATION]).toBe('MATCH');
+            expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe(
                 'MATCH (person:Person) RETURN person.name AS name'
             );
         });
@@ -345,7 +345,7 @@ describe('neo4j instrumentation', function () {
                     complete: () => {
                         const span = getSingleSpan();
                         assertSpan(span as ReadableSpan);
-                        expect(span.attributes[SemanticAttributes.DB_STATEMENT]).toBe(
+                        expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe(
                             'MERGE (james:Person {name: $nameParam}) RETURN james.name AS name'
                         );
                         done();
@@ -393,7 +393,7 @@ describe('neo4j instrumentation', function () {
                     complete: () => {
                         const span = getSingleSpan();
                         assertSpan(span as ReadableSpan);
-                        expect(span.attributes[SemanticAttributes.DB_STATEMENT]).toBe(
+                        expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe(
                             'MATCH (person:Person) RETURN person.name AS name'
                         );
                         done();
@@ -416,7 +416,7 @@ describe('neo4j instrumentation', function () {
                     complete: () => {
                         const span = getSingleSpan();
                         assertSpan(span as ReadableSpan);
-                        expect(span.attributes[SemanticAttributes.DB_STATEMENT]).toBe(
+                        expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe(
                             'MATCH (person:Person) RETURN person.name AS name'
                         );
                         done();

--- a/packages/instrumentation-neo4j/test/neo4j.spec.ts
+++ b/packages/instrumentation-neo4j/test/neo4j.spec.ts
@@ -289,9 +289,7 @@ describe('neo4j instrumentation', function () {
             const span = getSingleSpan();
             assertSpan(span as ReadableSpan);
             expect(span.attributes[SEMATTRS_DB_OPERATION]).toBe('MATCH');
-            expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe(
-                'MATCH (person:Person) RETURN person.name AS name'
-            );
+            expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe('MATCH (person:Person) RETURN person.name AS name');
         });
 
         it('instruments session writeTransaction', async () => {
@@ -301,9 +299,7 @@ describe('neo4j instrumentation', function () {
             const span = getSingleSpan();
             assertSpan(span as ReadableSpan);
             expect(span.attributes[SEMATTRS_DB_OPERATION]).toBe('MATCH');
-            expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe(
-                'MATCH (person:Person) RETURN person.name AS name'
-            );
+            expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe('MATCH (person:Person) RETURN person.name AS name');
         });
 
         it('instruments explicit transactions', async () => {

--- a/packages/instrumentation-node-cache/package.json
+++ b/packages/instrumentation-node-cache/package.json
@@ -57,7 +57,7 @@
         "node-cache": "^5.1.2",
         "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "test-all-versions": "^5.0.1",
-        "ts-node": "^9.1.1",
+        "ts-node": "^10.9.2",
         "typescript": "5.4.5"
     },
     "mocha": {

--- a/packages/instrumentation-node-cache/package.json
+++ b/packages/instrumentation-node-cache/package.json
@@ -55,7 +55,7 @@
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
         "node-cache": "^5.1.2",
-        "opentelemetry-instrumentation-mocha": "0.0.7-alpha.1",
+        "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "test-all-versions": "^5.0.1",
         "ts-node": "^9.1.1",
         "typescript": "4.3.4"
@@ -67,7 +67,7 @@
         "spec": "test/**/*.spec.ts",
         "require": [
             "ts-node/register",
-            "opentelemetry-instrumentation-mocha"
+            "aspecto-opentelemetry-instrumentation-mocha"
         ]
     }
 }

--- a/packages/instrumentation-node-cache/package.json
+++ b/packages/instrumentation-node-cache/package.json
@@ -42,14 +42,14 @@
         "@opentelemetry/api": "^1.8.0"
     },
     "dependencies": {
-        "@opentelemetry/contrib-test-utils": "^0.34.2",
+        "@opentelemetry/contrib-test-utils": "^0.39.0",
         "@opentelemetry/core": "^1.24.1",
         "@opentelemetry/instrumentation": "^0.51.1",
         "@opentelemetry/semantic-conventions": "^1.24.1"
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.8.0",
-        "@opentelemetry/contrib-test-utils": "^0.34.2",
+        "@opentelemetry/contrib-test-utils": "^0.39.0",
         "@opentelemetry/sdk-trace-base": "^1.24.1",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",

--- a/packages/instrumentation-node-cache/package.json
+++ b/packages/instrumentation-node-cache/package.json
@@ -58,7 +58,7 @@
         "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "test-all-versions": "^5.0.1",
         "ts-node": "^9.1.1",
-        "typescript": "4.3.4"
+        "typescript": "5.4.5"
     },
     "mocha": {
         "extension": [

--- a/packages/instrumentation-node-cache/package.json
+++ b/packages/instrumentation-node-cache/package.json
@@ -39,18 +39,18 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.6.0"
+        "@opentelemetry/api": "^1.8.0"
     },
     "dependencies": {
         "@opentelemetry/contrib-test-utils": "^0.34.2",
-        "@opentelemetry/core": "^1.17.1",
-        "@opentelemetry/instrumentation": "^0.44.0",
-        "@opentelemetry/semantic-conventions": "^1.17.1"
+        "@opentelemetry/core": "^1.24.1",
+        "@opentelemetry/instrumentation": "^0.51.1",
+        "@opentelemetry/semantic-conventions": "^1.24.1"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.6.0",
+        "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.34.2",
-        "@opentelemetry/sdk-trace-base": "^1.17.1",
+        "@opentelemetry/sdk-trace-base": "^1.24.1",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/packages/instrumentation-node-cache/src/node-cache.ts
+++ b/packages/instrumentation-node-cache/src/node-cache.ts
@@ -12,7 +12,7 @@ import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 
 type NodeCacheType = typeof NodeCache;
 
-export class NodeCacheInstrumentation extends InstrumentationBase<NodeCacheType> {
+export class NodeCacheInstrumentation extends InstrumentationBase {
     constructor(protected override _config: NodeCacheInstrumentationConfig = {}) {
         super('opentelemetry-instrumentation-node-cache', VERSION, _config);
     }
@@ -21,8 +21,8 @@ export class NodeCacheInstrumentation extends InstrumentationBase<NodeCacheType>
         this._config = config;
     }
 
-    protected init(): InstrumentationModuleDefinition<NodeCacheType> {
-        const module = new InstrumentationNodeModuleDefinition<NodeCacheType>(
+    protected init(): InstrumentationModuleDefinition{
+        const module = new InstrumentationNodeModuleDefinition(
             'node-cache',
             ['>=5.0.0'],
             this.patch.bind(this)

--- a/packages/instrumentation-node-cache/src/node-cache.ts
+++ b/packages/instrumentation-node-cache/src/node-cache.ts
@@ -8,7 +8,7 @@ import { NodeCacheInstrumentationConfig } from './types';
 import { VERSION } from './version';
 import { diag, SpanKind, SpanStatusCode, context, trace } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_DB_OPERATION, SEMATTRS_DB_STATEMENT, SEMATTRS_DB_SYSTEM, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 
 type NodeCacheType = typeof NodeCache;
 
@@ -80,9 +80,9 @@ export class NodeCacheInstrumentation extends InstrumentationBase {
                 const span = self.tracer.startSpan(`node-cache ${opName}`, {
                     kind: SpanKind.INTERNAL,
                     attributes: {
-                        [SemanticAttributes.DB_SYSTEM]: 'node-cache',
-                        [SemanticAttributes.DB_OPERATION]: opName,
-                        [SemanticAttributes.DB_STATEMENT]: toStatement(arguments),
+                        [SEMATTRS_DB_SYSTEM]: 'node-cache',
+                        [SEMATTRS_DB_OPERATION]: opName,
+                        [SEMATTRS_DB_STATEMENT]: toStatement(arguments),
                     },
                 });
 

--- a/packages/instrumentation-node-cache/src/node-cache.ts
+++ b/packages/instrumentation-node-cache/src/node-cache.ts
@@ -21,12 +21,8 @@ export class NodeCacheInstrumentation extends InstrumentationBase {
         this._config = config;
     }
 
-    protected init(): InstrumentationModuleDefinition{
-        const module = new InstrumentationNodeModuleDefinition(
-            'node-cache',
-            ['>=5.0.0'],
-            this.patch.bind(this)
-        );
+    protected init(): InstrumentationModuleDefinition {
+        const module = new InstrumentationNodeModuleDefinition('node-cache', ['>=5.0.0'], this.patch.bind(this));
         return module;
     }
 

--- a/packages/instrumentation-node-cache/src/node-cache.ts
+++ b/packages/instrumentation-node-cache/src/node-cache.ts
@@ -8,7 +8,12 @@ import { NodeCacheInstrumentationConfig } from './types';
 import { VERSION } from './version';
 import { diag, SpanKind, SpanStatusCode, context, trace } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
-import { SEMATTRS_DB_OPERATION, SEMATTRS_DB_STATEMENT, SEMATTRS_DB_SYSTEM, SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+    SEMATTRS_DB_OPERATION,
+    SEMATTRS_DB_STATEMENT,
+    SEMATTRS_DB_SYSTEM,
+    SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 
 type NodeCacheType = typeof NodeCache;
 

--- a/packages/instrumentation-node-cache/test/node-cache.spec.ts
+++ b/packages/instrumentation-node-cache/test/node-cache.spec.ts
@@ -9,7 +9,7 @@ const instrumentation = registerInstrumentationTesting(new NodeCacheInstrumentat
 instrumentation.enable();
 
 import NodeCache from 'node-cache';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_DB_OPERATION, SEMATTRS_DB_STATEMENT, SEMATTRS_DB_SYSTEM, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 
 describe('node-cache instrumentation', () => {
     let cache = new NodeCache();
@@ -40,8 +40,8 @@ describe('node-cache instrumentation', () => {
             const span = getSingleSpan();
 
             expect(span.name).toBe('node-cache set');
-            expect(span.attributes[SemanticAttributes.DB_SYSTEM]).toBe('node-cache');
-            expect(span.attributes[SemanticAttributes.DB_OPERATION]).toBe('set');
+            expect(span.attributes[SEMATTRS_DB_SYSTEM]).toBe('node-cache');
+            expect(span.attributes[SEMATTRS_DB_OPERATION]).toBe('set');
             expect(span.attributes[DB_RESPONSE]).toBe(true);
         });
 
@@ -52,9 +52,9 @@ describe('node-cache instrumentation', () => {
             const span = getSingleSpan();
 
             expect(span.name).toBe('node-cache get');
-            expect(span.attributes[SemanticAttributes.DB_SYSTEM]).toBe('node-cache');
-            expect(span.attributes[SemanticAttributes.DB_OPERATION]).toBe('get');
-            expect(span.attributes[SemanticAttributes.DB_STATEMENT]).toBe('get some-key');
+            expect(span.attributes[SEMATTRS_DB_SYSTEM]).toBe('node-cache');
+            expect(span.attributes[SEMATTRS_DB_OPERATION]).toBe('get');
+            expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe('get some-key');
             expect(span.attributes[DB_RESPONSE]).toBe('some-value');
         });
 
@@ -63,9 +63,9 @@ describe('node-cache instrumentation', () => {
             const span = getSingleSpan();
 
             expect(span.name).toBe('node-cache has');
-            expect(span.attributes[SemanticAttributes.DB_SYSTEM]).toBe('node-cache');
-            expect(span.attributes[SemanticAttributes.DB_OPERATION]).toBe('has');
-            expect(span.attributes[SemanticAttributes.DB_STATEMENT]).toBe('has some-key');
+            expect(span.attributes[SEMATTRS_DB_SYSTEM]).toBe('node-cache');
+            expect(span.attributes[SEMATTRS_DB_OPERATION]).toBe('has');
+            expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe('has some-key');
             expect(span.attributes[DB_RESPONSE]).toBe(false);
         });
 
@@ -78,9 +78,9 @@ describe('node-cache instrumentation', () => {
             const span = getSingleSpan();
 
             expect(span.name).toBe('node-cache take');
-            expect(span.attributes[SemanticAttributes.DB_SYSTEM]).toBe('node-cache');
-            expect(span.attributes[SemanticAttributes.DB_OPERATION]).toBe('take');
-            expect(span.attributes[SemanticAttributes.DB_STATEMENT]).toBe('take some-key');
+            expect(span.attributes[SEMATTRS_DB_SYSTEM]).toBe('node-cache');
+            expect(span.attributes[SEMATTRS_DB_OPERATION]).toBe('take');
+            expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe('take some-key');
             expect(span.attributes[DB_RESPONSE]).toBe('some-value');
         });
 
@@ -91,9 +91,9 @@ describe('node-cache instrumentation', () => {
             const span = getSingleSpan();
 
             expect(span.name).toBe('node-cache del');
-            expect(span.attributes[SemanticAttributes.DB_SYSTEM]).toBe('node-cache');
-            expect(span.attributes[SemanticAttributes.DB_OPERATION]).toBe('del');
-            expect(span.attributes[SemanticAttributes.DB_STATEMENT]).toBe('del some-key');
+            expect(span.attributes[SEMATTRS_DB_SYSTEM]).toBe('node-cache');
+            expect(span.attributes[SEMATTRS_DB_OPERATION]).toBe('del');
+            expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe('del some-key');
             expect(span.attributes[DB_RESPONSE]).toBe(1);
         });
 
@@ -105,9 +105,9 @@ describe('node-cache instrumentation', () => {
             const span = getSingleSpan();
 
             expect(span.name).toBe('node-cache del');
-            expect(span.attributes[SemanticAttributes.DB_SYSTEM]).toBe('node-cache');
-            expect(span.attributes[SemanticAttributes.DB_OPERATION]).toBe('del');
-            expect(span.attributes[SemanticAttributes.DB_STATEMENT]).toBe('del some-key,some-other-key');
+            expect(span.attributes[SEMATTRS_DB_SYSTEM]).toBe('node-cache');
+            expect(span.attributes[SEMATTRS_DB_OPERATION]).toBe('del');
+            expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe('del some-key,some-other-key');
             expect(span.attributes[DB_RESPONSE]).toBe(2);
         });
 
@@ -120,9 +120,9 @@ describe('node-cache instrumentation', () => {
             const span = getSingleSpan();
 
             expect(span.name).toBe('node-cache mget');
-            expect(span.attributes[SemanticAttributes.DB_SYSTEM]).toBe('node-cache');
-            expect(span.attributes[SemanticAttributes.DB_OPERATION]).toBe('mget');
-            expect(span.attributes[SemanticAttributes.DB_STATEMENT]).toBe('mget a,b,c');
+            expect(span.attributes[SEMATTRS_DB_SYSTEM]).toBe('node-cache');
+            expect(span.attributes[SEMATTRS_DB_OPERATION]).toBe('mget');
+            expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe('mget a,b,c');
             expect(JSON.parse(span.attributes[DB_RESPONSE] as string)).toEqual({ a: 'x', b: 'y' });
         });
 
@@ -134,9 +134,9 @@ describe('node-cache instrumentation', () => {
             const span = getSingleSpan();
 
             expect(span.name).toBe('node-cache mset');
-            expect(span.attributes[SemanticAttributes.DB_SYSTEM]).toBe('node-cache');
-            expect(span.attributes[SemanticAttributes.DB_OPERATION]).toBe('mset');
-            expect(span.attributes[SemanticAttributes.DB_STATEMENT]).toBe('mset a,b');
+            expect(span.attributes[SEMATTRS_DB_SYSTEM]).toBe('node-cache');
+            expect(span.attributes[SEMATTRS_DB_OPERATION]).toBe('mset');
+            expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe('mset a,b');
             expect(span.attributes[DB_RESPONSE]).toEqual(true);
         });
 
@@ -145,9 +145,9 @@ describe('node-cache instrumentation', () => {
             const span = getSingleSpan();
 
             expect(span.name).toBe('node-cache getTtl');
-            expect(span.attributes[SemanticAttributes.DB_SYSTEM]).toBe('node-cache');
-            expect(span.attributes[SemanticAttributes.DB_OPERATION]).toBe('getTtl');
-            expect(span.attributes[SemanticAttributes.DB_STATEMENT]).toBe('getTtl some-key');
+            expect(span.attributes[SEMATTRS_DB_SYSTEM]).toBe('node-cache');
+            expect(span.attributes[SEMATTRS_DB_OPERATION]).toBe('getTtl');
+            expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe('getTtl some-key');
         });
 
         it('ttl', () => {
@@ -155,9 +155,9 @@ describe('node-cache instrumentation', () => {
             const span = getSingleSpan();
 
             expect(span.name).toBe('node-cache ttl');
-            expect(span.attributes[SemanticAttributes.DB_SYSTEM]).toBe('node-cache');
-            expect(span.attributes[SemanticAttributes.DB_OPERATION]).toBe('ttl');
-            expect(span.attributes[SemanticAttributes.DB_STATEMENT]).toBe('ttl some-key 12345');
+            expect(span.attributes[SEMATTRS_DB_SYSTEM]).toBe('node-cache');
+            expect(span.attributes[SEMATTRS_DB_OPERATION]).toBe('ttl');
+            expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe('ttl some-key 12345');
         });
 
         it('flushAll', () => {
@@ -165,9 +165,9 @@ describe('node-cache instrumentation', () => {
             const span = getSingleSpan();
 
             expect(span.name).toBe('node-cache flushAll');
-            expect(span.attributes[SemanticAttributes.DB_SYSTEM]).toBe('node-cache');
-            expect(span.attributes[SemanticAttributes.DB_OPERATION]).toBe('flushAll');
-            expect(span.attributes[SemanticAttributes.DB_STATEMENT]).toBe('flushAll');
+            expect(span.attributes[SEMATTRS_DB_SYSTEM]).toBe('node-cache');
+            expect(span.attributes[SEMATTRS_DB_OPERATION]).toBe('flushAll');
+            expect(span.attributes[SEMATTRS_DB_STATEMENT]).toBe('flushAll');
         });
     });
 

--- a/packages/instrumentation-node-cache/test/node-cache.spec.ts
+++ b/packages/instrumentation-node-cache/test/node-cache.spec.ts
@@ -9,7 +9,12 @@ const instrumentation = registerInstrumentationTesting(new NodeCacheInstrumentat
 instrumentation.enable();
 
 import NodeCache from 'node-cache';
-import { SEMATTRS_DB_OPERATION, SEMATTRS_DB_STATEMENT, SEMATTRS_DB_SYSTEM, SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+    SEMATTRS_DB_OPERATION,
+    SEMATTRS_DB_STATEMENT,
+    SEMATTRS_DB_SYSTEM,
+    SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 
 describe('node-cache instrumentation', () => {
     let cache = new NodeCache();

--- a/packages/instrumentation-sequelize/package.json
+++ b/packages/instrumentation-sequelize/package.json
@@ -58,7 +58,7 @@
         "pg": "^8.4.2",
         "sequelize": "^5.22.0",
         "sqlite3": "^5.0.2",
-        "ts-node": "^9.1.1",
+        "ts-node": "^10.9.2",
         "typescript": "5.4.5"
     },
     "mocha": {

--- a/packages/instrumentation-sequelize/package.json
+++ b/packages/instrumentation-sequelize/package.json
@@ -39,17 +39,17 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.6.0"
+        "@opentelemetry/api": "^1.8.0"
     },
     "dependencies": {
-        "@opentelemetry/core": "^1.17.1",
-        "@opentelemetry/instrumentation": "^0.44.0",
-        "@opentelemetry/semantic-conventions": "^1.17.1"
+        "@opentelemetry/core": "^1.24.1",
+        "@opentelemetry/instrumentation": "^0.51.1",
+        "@opentelemetry/semantic-conventions": "^1.24.1"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.6.0",
+        "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.34.2",
-        "@opentelemetry/sdk-trace-base": "^1.17.1",
+        "@opentelemetry/sdk-trace-base": "^1.24.1",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/packages/instrumentation-sequelize/package.json
+++ b/packages/instrumentation-sequelize/package.json
@@ -54,7 +54,7 @@
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
         "mysql2": "^2.2.5",
-        "opentelemetry-instrumentation-mocha": "0.0.7-alpha.1",
+        "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "pg": "^8.4.2",
         "sequelize": "^5.22.0",
         "sqlite3": "^5.0.2",
@@ -68,7 +68,7 @@
         "spec": "test/**/*.spec.ts",
         "require": [
             "ts-node/register",
-            "opentelemetry-instrumentation-mocha"
+            "aspecto-opentelemetry-instrumentation-mocha"
         ]
     }
 }

--- a/packages/instrumentation-sequelize/package.json
+++ b/packages/instrumentation-sequelize/package.json
@@ -48,7 +48,7 @@
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.8.0",
-        "@opentelemetry/contrib-test-utils": "^0.34.2",
+        "@opentelemetry/contrib-test-utils": "^0.39.0",
         "@opentelemetry/sdk-trace-base": "^1.24.1",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",

--- a/packages/instrumentation-sequelize/package.json
+++ b/packages/instrumentation-sequelize/package.json
@@ -59,7 +59,7 @@
         "sequelize": "^5.22.0",
         "sqlite3": "^5.0.2",
         "ts-node": "^9.1.1",
-        "typescript": "4.3.4"
+        "typescript": "5.4.5"
     },
     "mocha": {
         "extension": [

--- a/packages/instrumentation-sequelize/src/sequelize.ts
+++ b/packages/instrumentation-sequelize/src/sequelize.ts
@@ -1,6 +1,6 @@
 import { context, Span, SpanKind, SpanStatusCode, trace, diag } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
-import { NetTransportValues, SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { NetTransportValues, SEMATTRS_NET_TRANSPORT, SEMATTRS_DB_NAME, SEMATTRS_DB_OPERATION, SEMATTRS_DB_SQL_TABLE, SEMATTRS_DB_STATEMENT, SEMATTRS_DB_SYSTEM, SEMATTRS_DB_USER, SEMATTRS_NET_PEER_NAME, SEMATTRS_NET_PEER_PORT, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import * as sequelize from 'sequelize';
 import { SequelizeInstrumentationConfig } from './types';
 import { VERSION } from './version';
@@ -115,16 +115,16 @@ export class SequelizeInstrumentation extends InstrumentationBase {
             }
 
             const attributes = {
-                [SemanticAttributes.DB_SYSTEM]: sequelizeInstance.getDialect(),
-                [SemanticAttributes.DB_USER]: config?.username,
-                [SemanticAttributes.NET_PEER_NAME]: config?.host,
-                [SemanticAttributes.NET_PEER_PORT]: config?.port ? Number(config?.port) : undefined,
-                [SemanticAttributes.NET_TRANSPORT]: self._getNetTransport(config?.protocol),
-                [SemanticAttributes.DB_NAME]: config?.database,
-                [SemanticAttributes.DB_OPERATION]: operation,
-                [SemanticAttributes.DB_STATEMENT]: statement,
-                [SemanticAttributes.DB_SQL_TABLE]: tableName,
-                // [SemanticAttributes.NET_PEER_IP]: '?', // Part of protocol
+                [SEMATTRS_DB_SYSTEM]: sequelizeInstance.getDialect(),
+                [SEMATTRS_DB_USER]: config?.username,
+                [SEMATTRS_NET_PEER_NAME]: config?.host,
+                [SEMATTRS_NET_PEER_PORT]: config?.port ? Number(config?.port) : undefined,
+                [SEMATTRS_NET_TRANSPORT]: self._getNetTransport(config?.protocol),
+                [SEMATTRS_DB_NAME]: config?.database,
+                [SEMATTRS_DB_OPERATION]: operation,
+                [SEMATTRS_DB_STATEMENT]: statement,
+                [SEMATTRS_DB_SQL_TABLE]: tableName,
+                // [SEMATTRS_NET_PEER_IPPEER_IP]: '?', // Part of protocol
             };
 
             if (self._config.moduleVersionAttributeName) {

--- a/packages/instrumentation-sequelize/src/sequelize.ts
+++ b/packages/instrumentation-sequelize/src/sequelize.ts
@@ -14,7 +14,7 @@ import {
     safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
 
-export class SequelizeInstrumentation extends InstrumentationBase<typeof sequelize> {
+export class SequelizeInstrumentation extends InstrumentationBase {
     static readonly component = 'sequelize';
     protected override _config!: SequelizeInstrumentationConfig;
     private moduleVersion: string;
@@ -27,15 +27,15 @@ export class SequelizeInstrumentation extends InstrumentationBase<typeof sequeli
         this._config = Object.assign({}, config);
     }
 
-    protected init(): InstrumentationModuleDefinition<typeof sequelize> {
-        const connectionManagerInstrumentation = new InstrumentationNodeModuleFile<any>(
+    protected init(): InstrumentationModuleDefinition {
+        const connectionManagerInstrumentation = new InstrumentationNodeModuleFile(
             'sequelize/lib/dialects/abstract/connection-manager.js',
             ['*'],
             this.patchConnectionManager.bind(this),
             this.unpatchConnectionManager.bind(this)
         );
 
-        const module = new InstrumentationNodeModuleDefinition<typeof sequelize>(
+        const module = new InstrumentationNodeModuleDefinition(
             SequelizeInstrumentation.component,
             ['*'],
             this.patch.bind(this),

--- a/packages/instrumentation-sequelize/src/sequelize.ts
+++ b/packages/instrumentation-sequelize/src/sequelize.ts
@@ -1,6 +1,18 @@
 import { context, Span, SpanKind, SpanStatusCode, trace, diag } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
-import { NetTransportValues, SEMATTRS_NET_TRANSPORT, SEMATTRS_DB_NAME, SEMATTRS_DB_OPERATION, SEMATTRS_DB_SQL_TABLE, SEMATTRS_DB_STATEMENT, SEMATTRS_DB_SYSTEM, SEMATTRS_DB_USER, SEMATTRS_NET_PEER_NAME, SEMATTRS_NET_PEER_PORT, SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+    NetTransportValues,
+    SEMATTRS_NET_TRANSPORT,
+    SEMATTRS_DB_NAME,
+    SEMATTRS_DB_OPERATION,
+    SEMATTRS_DB_SQL_TABLE,
+    SEMATTRS_DB_STATEMENT,
+    SEMATTRS_DB_SYSTEM,
+    SEMATTRS_DB_USER,
+    SEMATTRS_NET_PEER_NAME,
+    SEMATTRS_NET_PEER_PORT,
+    SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import * as sequelize from 'sequelize';
 import { SequelizeInstrumentationConfig } from './types';
 import { VERSION } from './version';

--- a/packages/instrumentation-sequelize/test/sequelize.spec.ts
+++ b/packages/instrumentation-sequelize/test/sequelize.spec.ts
@@ -4,7 +4,17 @@ import { SequelizeInstrumentation } from '../src';
 import { extractTableFromQuery } from '../src/utils';
 import { ReadableSpan, Span } from '@opentelemetry/sdk-trace-base';
 import { context, diag, SpanStatusCode, DiagConsoleLogger, ROOT_CONTEXT } from '@opentelemetry/api';
-import { SEMATTRS_DB_NAME, SEMATTRS_DB_OPERATION, SEMATTRS_DB_SQL_TABLE, SEMATTRS_DB_STATEMENT, SEMATTRS_DB_SYSTEM, SEMATTRS_DB_USER, SEMATTRS_NET_PEER_NAME, SEMATTRS_NET_PEER_PORT, SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+    SEMATTRS_DB_NAME,
+    SEMATTRS_DB_OPERATION,
+    SEMATTRS_DB_SQL_TABLE,
+    SEMATTRS_DB_STATEMENT,
+    SEMATTRS_DB_SYSTEM,
+    SEMATTRS_DB_USER,
+    SEMATTRS_NET_PEER_NAME,
+    SEMATTRS_NET_PEER_PORT,
+    SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import { getTestSpans, registerInstrumentationTesting } from '@opentelemetry/contrib-test-utils';
 
 // should be available in node_modules from sequelize installation
@@ -98,9 +108,7 @@ describe('instrumentation-sequelize', () => {
 
             expect(attributes[SEMATTRS_DB_OPERATION]).toBe('SELECT');
             expect(attributes[SEMATTRS_DB_SQL_TABLE]).toBe('Users');
-            expect(attributes[SEMATTRS_DB_STATEMENT]).toBe(
-                'SELECT count(*) AS "count" FROM "Users" AS "User";'
-            );
+            expect(attributes[SEMATTRS_DB_STATEMENT]).toBe('SELECT count(*) AS "count" FROM "Users" AS "User";');
         });
 
         it('handled complex query', async () => {

--- a/packages/instrumentation-sequelize/test/sequelize.spec.ts
+++ b/packages/instrumentation-sequelize/test/sequelize.spec.ts
@@ -4,7 +4,7 @@ import { SequelizeInstrumentation } from '../src';
 import { extractTableFromQuery } from '../src/utils';
 import { ReadableSpan, Span } from '@opentelemetry/sdk-trace-base';
 import { context, diag, SpanStatusCode, DiagConsoleLogger, ROOT_CONTEXT } from '@opentelemetry/api';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_DB_NAME, SEMATTRS_DB_OPERATION, SEMATTRS_DB_SQL_TABLE, SEMATTRS_DB_STATEMENT, SEMATTRS_DB_SYSTEM, SEMATTRS_DB_USER, SEMATTRS_NET_PEER_NAME, SEMATTRS_NET_PEER_PORT, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { getTestSpans, registerInstrumentationTesting } from '@opentelemetry/contrib-test-utils';
 
 // should be available in node_modules from sequelize installation
@@ -54,14 +54,14 @@ describe('instrumentation-sequelize', () => {
             expect(spans[0].status.code).toBe(SpanStatusCode.ERROR);
             const attributes = spans[0].attributes;
 
-            expect(attributes[SemanticAttributes.DB_SYSTEM]).toBe(DB_SYSTEM);
-            expect(attributes[SemanticAttributes.DB_USER]).toBe(DB_USER);
-            expect(attributes[SemanticAttributes.NET_PEER_NAME]).toBe(NET_PEER_NAME);
-            expect(attributes[SemanticAttributes.NET_PEER_PORT]).toBe(NET_PEER_PORT);
-            expect(attributes[SemanticAttributes.DB_NAME]).toBe(DB_NAME);
-            expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('INSERT');
-            expect(attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('Users');
-            expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe(
+            expect(attributes[SEMATTRS_DB_SYSTEM]).toBe(DB_SYSTEM);
+            expect(attributes[SEMATTRS_DB_USER]).toBe(DB_USER);
+            expect(attributes[SEMATTRS_NET_PEER_NAME]).toBe(NET_PEER_NAME);
+            expect(attributes[SEMATTRS_NET_PEER_PORT]).toBe(NET_PEER_PORT);
+            expect(attributes[SEMATTRS_DB_NAME]).toBe(DB_NAME);
+            expect(attributes[SEMATTRS_DB_OPERATION]).toBe('INSERT');
+            expect(attributes[SEMATTRS_DB_SQL_TABLE]).toBe('Users');
+            expect(attributes[SEMATTRS_DB_STATEMENT]).toBe(
                 'INSERT INTO "Users" ("id","firstName","createdAt","updatedAt") VALUES (DEFAULT,$1,$2,$3) RETURNING *;'
             );
         });
@@ -72,9 +72,9 @@ describe('instrumentation-sequelize', () => {
             expect(spans.length).toBe(1);
             const attributes = spans[0].attributes;
 
-            expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('SELECT');
-            expect(attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('Users');
-            expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe(
+            expect(attributes[SEMATTRS_DB_OPERATION]).toBe('SELECT');
+            expect(attributes[SEMATTRS_DB_SQL_TABLE]).toBe('Users');
+            expect(attributes[SEMATTRS_DB_STATEMENT]).toBe(
                 'SELECT "id", "firstName", "createdAt", "updatedAt" FROM "Users" AS "User";'
             );
         });
@@ -85,9 +85,9 @@ describe('instrumentation-sequelize', () => {
             expect(spans.length).toBe(1);
             const attributes = spans[0].attributes;
 
-            expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('BULKDELETE');
-            expect(attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('Users');
-            expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe('TRUNCATE "Users"');
+            expect(attributes[SEMATTRS_DB_OPERATION]).toBe('BULKDELETE');
+            expect(attributes[SEMATTRS_DB_SQL_TABLE]).toBe('Users');
+            expect(attributes[SEMATTRS_DB_STATEMENT]).toBe('TRUNCATE "Users"');
         });
 
         it('count is instrumented', async () => {
@@ -96,9 +96,9 @@ describe('instrumentation-sequelize', () => {
             expect(spans.length).toBe(1);
             const attributes = spans[0].attributes;
 
-            expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('SELECT');
-            expect(attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('Users');
-            expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe(
+            expect(attributes[SEMATTRS_DB_OPERATION]).toBe('SELECT');
+            expect(attributes[SEMATTRS_DB_SQL_TABLE]).toBe('Users');
+            expect(attributes[SEMATTRS_DB_STATEMENT]).toBe(
                 'SELECT count(*) AS "count" FROM "Users" AS "User";'
             );
         });
@@ -125,9 +125,9 @@ describe('instrumentation-sequelize', () => {
             expect(spans.length).toBe(1);
             const attributes = spans[0].attributes;
 
-            expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('SELECT');
-            expect(attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('Users');
-            expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe(
+            expect(attributes[SEMATTRS_DB_OPERATION]).toBe('SELECT');
+            expect(attributes[SEMATTRS_DB_SQL_TABLE]).toBe('Users');
+            expect(attributes[SEMATTRS_DB_STATEMENT]).toBe(
                 `SELECT "id", "username" FROM "Users" AS "User" WHERE "User"."username" = 'Shlomi' AND ("User"."rank" < 1000 OR "User"."rank" IS NULL) ORDER BY "User"."username" DESC LIMIT 10 OFFSET 5;`
             );
         });
@@ -141,7 +141,7 @@ describe('instrumentation-sequelize', () => {
             const spans = getSequelizeSpans();
             expect(spans.length).toBe(1);
             const attributes = spans[0].attributes;
-            expect(attributes[SemanticAttributes.DB_SQL_TABLE]).toBe(expectedTableName);
+            expect(attributes[SEMATTRS_DB_SQL_TABLE]).toBe(expectedTableName);
         });
 
         it('handles JOIN queries', async () => {
@@ -171,9 +171,9 @@ describe('instrumentation-sequelize', () => {
             expect(spans.length).toBe(1);
             const attributes = spans[0].attributes;
 
-            expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('SELECT');
-            expect(attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('Dogs,Users');
-            expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe(
+            expect(attributes[SEMATTRS_DB_OPERATION]).toBe('SELECT');
+            expect(attributes[SEMATTRS_DB_SQL_TABLE]).toBe('Dogs,Users');
+            expect(attributes[SEMATTRS_DB_STATEMENT]).toBe(
                 `SELECT "Dog"."id", "Dog"."firstName", "Dog"."owner", "User"."id" AS "User.id", "User"."firstName" AS "User.firstName" FROM "Dogs" AS "Dog" INNER JOIN "Users" AS "User" ON "Dog"."firstName" = "User"."id" LIMIT 1;`
             );
         });
@@ -201,14 +201,14 @@ describe('instrumentation-sequelize', () => {
             expect(spans[0].status.code).toBe(SpanStatusCode.ERROR);
             const attributes = spans[0].attributes;
 
-            expect(attributes[SemanticAttributes.DB_SYSTEM]).toBe(DB_SYSTEM);
-            expect(attributes[SemanticAttributes.DB_USER]).toBe(DB_USER);
-            expect(attributes[SemanticAttributes.NET_PEER_NAME]).toBe(NET_PEER_NAME);
-            expect(attributes[SemanticAttributes.NET_PEER_PORT]).toBe(NET_PEER_PORT);
-            expect(attributes[SemanticAttributes.DB_NAME]).toBe(DB_NAME);
-            expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('INSERT');
-            expect(attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('Users');
-            expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe(
+            expect(attributes[SEMATTRS_DB_SYSTEM]).toBe(DB_SYSTEM);
+            expect(attributes[SEMATTRS_DB_USER]).toBe(DB_USER);
+            expect(attributes[SEMATTRS_NET_PEER_NAME]).toBe(NET_PEER_NAME);
+            expect(attributes[SEMATTRS_NET_PEER_PORT]).toBe(NET_PEER_PORT);
+            expect(attributes[SEMATTRS_DB_NAME]).toBe(DB_NAME);
+            expect(attributes[SEMATTRS_DB_OPERATION]).toBe('INSERT');
+            expect(attributes[SEMATTRS_DB_SQL_TABLE]).toBe('Users');
+            expect(attributes[SEMATTRS_DB_STATEMENT]).toBe(
                 'INSERT INTO `Users` (`id`,`firstName`,`createdAt`,`updatedAt`) VALUES (DEFAULT,$1,$2,$3);'
             );
         });
@@ -219,9 +219,9 @@ describe('instrumentation-sequelize', () => {
             expect(spans.length).toBe(1);
             const attributes = spans[0].attributes;
 
-            expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('SELECT');
-            expect(attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('Users');
-            expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe(
+            expect(attributes[SEMATTRS_DB_OPERATION]).toBe('SELECT');
+            expect(attributes[SEMATTRS_DB_SQL_TABLE]).toBe('Users');
+            expect(attributes[SEMATTRS_DB_STATEMENT]).toBe(
                 'SELECT `id`, `firstName`, `createdAt`, `updatedAt` FROM `Users` AS `User`;'
             );
         });
@@ -237,8 +237,8 @@ describe('instrumentation-sequelize', () => {
                 expect(spans.length).toBe(1);
                 const attributes = spans[0].attributes;
 
-                expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('SELECT');
-                expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe('SELECT 1 + 1');
+                expect(attributes[SEMATTRS_DB_OPERATION]).toBe('SELECT');
+                expect(attributes[SEMATTRS_DB_STATEMENT]).toBe('SELECT 1 + 1');
             });
             it('with type not specified in options', async () => {
                 try {
@@ -250,8 +250,8 @@ describe('instrumentation-sequelize', () => {
                 expect(spans.length).toBe(1);
                 const attributes = spans[0].attributes;
 
-                expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('SELECT');
-                expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe('SELECT 1 + 1');
+                expect(attributes[SEMATTRS_DB_OPERATION]).toBe('SELECT');
+                expect(attributes[SEMATTRS_DB_STATEMENT]).toBe('SELECT 1 + 1');
             });
 
             it('with type specified in options', async () => {
@@ -264,8 +264,8 @@ describe('instrumentation-sequelize', () => {
                 expect(spans.length).toBe(1);
                 const attributes = spans[0].attributes;
 
-                expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('RAW');
-                expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe('SELECT 1 + 1');
+                expect(attributes[SEMATTRS_DB_OPERATION]).toBe('RAW');
+                expect(attributes[SEMATTRS_DB_STATEMENT]).toBe('SELECT 1 + 1');
             });
         });
     });
@@ -281,11 +281,11 @@ describe('instrumentation-sequelize', () => {
             const spans = getSequelizeSpans();
             expect(spans.length).toBe(1);
             const attributes = spans[0].attributes;
-            expect(attributes[SemanticAttributes.DB_SYSTEM]).toBe('sqlite');
-            expect(attributes[SemanticAttributes.NET_PEER_NAME]).toBe('memory');
-            expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('INSERT');
-            expect(attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('Users');
-            expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe(
+            expect(attributes[SEMATTRS_DB_SYSTEM]).toBe('sqlite');
+            expect(attributes[SEMATTRS_NET_PEER_NAME]).toBe('memory');
+            expect(attributes[SEMATTRS_DB_OPERATION]).toBe('INSERT');
+            expect(attributes[SEMATTRS_DB_SQL_TABLE]).toBe('Users');
+            expect(attributes[SEMATTRS_DB_STATEMENT]).toBe(
                 'INSERT INTO `Users` (`id`,`firstName`,`createdAt`,`updatedAt`) VALUES (NULL,$1,$2,$3);'
             );
         });

--- a/packages/instrumentation-typeorm/package.json
+++ b/packages/instrumentation-typeorm/package.json
@@ -35,18 +35,18 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.6.0"
+        "@opentelemetry/api": "^1.8.0"
     },
     "dependencies": {
-        "@opentelemetry/core": "^1.17.1",
-        "@opentelemetry/instrumentation": "^0.44.0",
-        "@opentelemetry/semantic-conventions": "^1.17.1",
+        "@opentelemetry/core": "^1.24.1",
+        "@opentelemetry/instrumentation": "^0.51.1",
+        "@opentelemetry/semantic-conventions": "^1.24.1",
         "is-promise": "^4.0.0"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.6.0",
+        "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.34.2",
-        "@opentelemetry/sdk-trace-base": "^1.17.1",
+        "@opentelemetry/sdk-trace-base": "^1.24.1",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/packages/instrumentation-typeorm/package.json
+++ b/packages/instrumentation-typeorm/package.json
@@ -50,7 +50,7 @@
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
-        "opentelemetry-instrumentation-mocha": "0.0.7-alpha.1",
+        "aspecto-opentelemetry-instrumentation-mocha": "0.0.9-alpha.0",
         "reflect-metadata": "^0.1.13",
         "sqlite3": "^5.0.2",
         "test-all-versions": "^5.0.1",
@@ -65,7 +65,7 @@
         "spec": "test/**/*.spec.ts",
         "require": [
             "ts-node/register",
-            "opentelemetry-instrumentation-mocha"
+            "aspecto-opentelemetry-instrumentation-mocha"
         ]
     }
 }

--- a/packages/instrumentation-typeorm/package.json
+++ b/packages/instrumentation-typeorm/package.json
@@ -54,7 +54,7 @@
         "reflect-metadata": "^0.1.13",
         "sqlite3": "^5.0.2",
         "test-all-versions": "^5.0.1",
-        "ts-node": "^9.1.1",
+        "ts-node": "^10.9.2",
         "typeorm": "^0.2.26",
         "typescript": "5.4.5"
     },

--- a/packages/instrumentation-typeorm/package.json
+++ b/packages/instrumentation-typeorm/package.json
@@ -56,7 +56,7 @@
         "test-all-versions": "^5.0.1",
         "ts-node": "^9.1.1",
         "typeorm": "^0.2.26",
-        "typescript": "4.3.4"
+        "typescript": "5.4.5"
     },
     "mocha": {
         "extension": [

--- a/packages/instrumentation-typeorm/package.json
+++ b/packages/instrumentation-typeorm/package.json
@@ -45,7 +45,7 @@
     },
     "devDependencies": {
         "@opentelemetry/api": "^1.8.0",
-        "@opentelemetry/contrib-test-utils": "^0.34.2",
+        "@opentelemetry/contrib-test-utils": "^0.39.0",
         "@opentelemetry/sdk-trace-base": "^1.24.1",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",

--- a/packages/instrumentation-typeorm/src/typeorm.ts
+++ b/packages/instrumentation-typeorm/src/typeorm.ts
@@ -1,6 +1,6 @@
 import { Span, SpanKind, SpanStatusCode, trace, context, diag } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_DB_NAME, SEMATTRS_DB_OPERATION, SEMATTRS_DB_SQL_TABLE, SEMATTRS_DB_STATEMENT, SEMATTRS_DB_SYSTEM, SEMATTRS_DB_USER, SEMATTRS_NET_PEER_NAME, SEMATTRS_NET_PEER_PORT, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { ExtendedDatabaseAttribute, TypeormInstrumentationConfig } from './types';
 import { getParamNames, isTypeormInternalTracingSuppressed, suppressTypeormInternalTracing } from './utils';
 import { VERSION } from './version';
@@ -167,13 +167,13 @@ export class TypeormInstrumentation extends InstrumentationBase {
                 }
                 const connectionOptions = this?.connection?.options ?? {};
                 const attributes = {
-                    [SemanticAttributes.DB_SYSTEM]: connectionOptions.type,
-                    [SemanticAttributes.DB_USER]: connectionOptions.username,
-                    [SemanticAttributes.NET_PEER_NAME]: connectionOptions.host,
-                    [SemanticAttributes.NET_PEER_PORT]: connectionOptions.port,
-                    [SemanticAttributes.DB_NAME]: connectionOptions.database,
-                    [SemanticAttributes.DB_OPERATION]: opName,
-                    [SemanticAttributes.DB_STATEMENT]: JSON.stringify(buildStatement(original, args)),
+                    [SEMATTRS_DB_SYSTEM]: connectionOptions.type,
+                    [SEMATTRS_DB_USER]: connectionOptions.username,
+                    [SEMATTRS_NET_PEER_NAME]: connectionOptions.host,
+                    [SEMATTRS_NET_PEER_PORT]: connectionOptions.port,
+                    [SEMATTRS_DB_NAME]: connectionOptions.database,
+                    [SEMATTRS_DB_OPERATION]: opName,
+                    [SEMATTRS_DB_STATEMENT]: JSON.stringify(buildStatement(original, args)),
                 };
 
                 if (self._config.moduleVersionAttributeName && moduleVersion) {
@@ -183,13 +183,13 @@ export class TypeormInstrumentation extends InstrumentationBase {
                 //ignore EntityMetadataNotFoundError
                 try {
                     if (this.metadata) {
-                        attributes[SemanticAttributes.DB_SQL_TABLE] = this.metadata.tableName;
+                        attributes[SEMATTRS_DB_SQL_TABLE] = this.metadata.tableName;
                     } else {
                         const entity = args[0];
                         const name = typeof entity === 'object' ? entity?.constructor?.name : entity;
                         const metadata = this.connection.getMetadata(name);
                         if (metadata?.tableName) {
-                            attributes[SemanticAttributes.DB_SQL_TABLE] = metadata.tableName;
+                            attributes[SEMATTRS_DB_SQL_TABLE] = metadata.tableName;
                         }
                     }
                 } catch {}
@@ -234,14 +234,14 @@ export class TypeormInstrumentation extends InstrumentationBase {
                 const operation = queryBuilder.expressionMap.queryType;
                 const connectionOptions: any = queryBuilder?.connection?.options;
                 const attributes = {
-                    [SemanticAttributes.DB_SYSTEM]: connectionOptions.type,
-                    [SemanticAttributes.DB_USER]: connectionOptions.username,
-                    [SemanticAttributes.NET_PEER_NAME]: connectionOptions.host,
-                    [SemanticAttributes.NET_PEER_PORT]: connectionOptions.port,
-                    [SemanticAttributes.DB_NAME]: connectionOptions.database,
-                    [SemanticAttributes.DB_OPERATION]: operation,
-                    [SemanticAttributes.DB_STATEMENT]: sql,
-                    [SemanticAttributes.DB_SQL_TABLE]: mainTableName,
+                    [SEMATTRS_DB_SYSTEM]: connectionOptions.type,
+                    [SEMATTRS_DB_USER]: connectionOptions.username,
+                    [SEMATTRS_NET_PEER_NAME]: connectionOptions.host,
+                    [SEMATTRS_NET_PEER_PORT]: connectionOptions.port,
+                    [SEMATTRS_DB_NAME]: connectionOptions.database,
+                    [SEMATTRS_DB_OPERATION]: operation,
+                    [SEMATTRS_DB_STATEMENT]: sql,
+                    [SEMATTRS_DB_SQL_TABLE]: mainTableName,
                 };
                 if (self._config.collectParameters) {
                     try {
@@ -294,13 +294,13 @@ export class TypeormInstrumentation extends InstrumentationBase {
                 const operation = self.getOperationName(sql);
                 const connectionOptions: any = conn.options;
                 const attributes = {
-                    [SemanticAttributes.DB_SYSTEM]: connectionOptions.type,
-                    [SemanticAttributes.DB_USER]: connectionOptions.username,
-                    [SemanticAttributes.NET_PEER_NAME]: connectionOptions.host,
-                    [SemanticAttributes.NET_PEER_PORT]: connectionOptions.port,
-                    [SemanticAttributes.DB_NAME]: connectionOptions.database,
-                    [SemanticAttributes.DB_OPERATION]: operation,
-                    [SemanticAttributes.DB_STATEMENT]: sql,
+                    [SEMATTRS_DB_SYSTEM]: connectionOptions.type,
+                    [SEMATTRS_DB_USER]: connectionOptions.username,
+                    [SEMATTRS_NET_PEER_NAME]: connectionOptions.host,
+                    [SEMATTRS_NET_PEER_PORT]: connectionOptions.port,
+                    [SEMATTRS_DB_NAME]: connectionOptions.database,
+                    [SEMATTRS_DB_OPERATION]: operation,
+                    [SEMATTRS_DB_STATEMENT]: sql,
                 };
 
                 const span: Span = self.tracer.startSpan(`TypeORM ${operation}`, {

--- a/packages/instrumentation-typeorm/src/typeorm.ts
+++ b/packages/instrumentation-typeorm/src/typeorm.ts
@@ -49,14 +49,14 @@ const entityManagerMethods: EntityManagerMethods[] = [
     ...functionsUsingQueryBuilder,
 ];
 
-export class TypeormInstrumentation extends InstrumentationBase<any> {
+export class TypeormInstrumentation extends InstrumentationBase {
     protected override _config!: TypeormInstrumentationConfig;
     constructor(config: TypeormInstrumentationConfig = {}) {
         super('opentelemetry-instrumentation-typeorm', VERSION, Object.assign({}, config));
     }
 
-    protected init(): InstrumentationModuleDefinition<any> {
-        const selectQueryBuilder = new InstrumentationNodeModuleFile<any>(
+    protected init(): InstrumentationModuleDefinition {
+        const selectQueryBuilder = new InstrumentationNodeModuleFile(
             'typeorm/query-builder/SelectQueryBuilder.js',
             ['>0.2.28'],
             (moduleExports, moduleVersion) => {
@@ -83,7 +83,7 @@ export class TypeormInstrumentation extends InstrumentationBase<any> {
             }
         );
 
-        const connection = new InstrumentationNodeModuleFile<any>(
+        const connection = new InstrumentationNodeModuleFile(
             'typeorm/connection/Connection.js',
             ['>0.2.28 <0.3.0'],
             (moduleExports, moduleVersion) => {
@@ -102,7 +102,7 @@ export class TypeormInstrumentation extends InstrumentationBase<any> {
             }
         );
 
-        const dataSource = new InstrumentationNodeModuleFile<any>(
+        const dataSource = new InstrumentationNodeModuleFile(
             'typeorm/data-source/DataSource.js',
             ['>=0.3.0'],
             (moduleExports, moduleVersion) => {
@@ -121,7 +121,7 @@ export class TypeormInstrumentation extends InstrumentationBase<any> {
             }
         );
 
-        const entityManager = new InstrumentationNodeModuleFile<any>(
+        const entityManager = new InstrumentationNodeModuleFile(
             'typeorm/entity-manager/EntityManager.js',
             ['>0.2.28'],
             (moduleExports, moduleVersion) => {
@@ -148,7 +148,7 @@ export class TypeormInstrumentation extends InstrumentationBase<any> {
             }
         );
 
-        const module = new InstrumentationNodeModuleDefinition<any>('typeorm', ['>0.2.28'], null, null, [
+        const module = new InstrumentationNodeModuleDefinition('typeorm', ['>0.2.28'], null, null, [
             selectQueryBuilder,
             entityManager,
             connection,

--- a/packages/instrumentation-typeorm/src/typeorm.ts
+++ b/packages/instrumentation-typeorm/src/typeorm.ts
@@ -1,6 +1,16 @@
 import { Span, SpanKind, SpanStatusCode, trace, context, diag } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
-import { SEMATTRS_DB_NAME, SEMATTRS_DB_OPERATION, SEMATTRS_DB_SQL_TABLE, SEMATTRS_DB_STATEMENT, SEMATTRS_DB_SYSTEM, SEMATTRS_DB_USER, SEMATTRS_NET_PEER_NAME, SEMATTRS_NET_PEER_PORT, SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+    SEMATTRS_DB_NAME,
+    SEMATTRS_DB_OPERATION,
+    SEMATTRS_DB_SQL_TABLE,
+    SEMATTRS_DB_STATEMENT,
+    SEMATTRS_DB_SYSTEM,
+    SEMATTRS_DB_USER,
+    SEMATTRS_NET_PEER_NAME,
+    SEMATTRS_NET_PEER_PORT,
+    SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import { ExtendedDatabaseAttribute, TypeormInstrumentationConfig } from './types';
 import { getParamNames, isTypeormInternalTracingSuppressed, suppressTypeormInternalTracing } from './utils';
 import { VERSION } from './version';

--- a/packages/instrumentation-typeorm/src/utils/get-func-param-names.ts
+++ b/packages/instrumentation-typeorm/src/utils/get-func-param-names.ts
@@ -3,7 +3,9 @@ const ARGUMENT_NAMES = /([^\s,]+)/g;
 
 export function getParamNames(func: Function) {
     const fnStr = func.toString().replace(STRIP_COMMENTS, '');
-    let result = fnStr.slice(fnStr.indexOf('(') + 1, fnStr.indexOf(')')).match(ARGUMENT_NAMES);
-    if (result === null) result = [];
+    let result = fnStr.slice(fnStr.indexOf('(') + 1, fnStr.indexOf(')')).match(ARGUMENT_NAMES) as any;
+    if (result === null) {
+        result = [];
+    }
     return result;
 }

--- a/packages/instrumentation-typeorm/test/Connection.spec.ts
+++ b/packages/instrumentation-typeorm/test/Connection.spec.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import expect from 'expect';
 import { SpanStatusCode } from '@opentelemetry/api';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_DB_NAME, SEMATTRS_DB_OPERATION, SEMATTRS_DB_STATEMENT, SEMATTRS_DB_SYSTEM, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { TypeormInstrumentation } from '../src';
 import { getTestSpans, registerInstrumentationTesting } from '@opentelemetry/contrib-test-utils';
 
@@ -31,10 +31,10 @@ describe('Connection', () => {
             expect(typeOrmSpans.length).toBe(1);
             expect(typeOrmSpans[0].status.code).toBe(SpanStatusCode.UNSET);
             const attributes = typeOrmSpans[0].attributes;
-            expect(attributes[SemanticAttributes.DB_SYSTEM]).toBe(options.type);
-            expect(attributes[SemanticAttributes.DB_NAME]).toBe(options.database);
-            expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('SELECT');
-            expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe(query);
+            expect(attributes[SEMATTRS_DB_SYSTEM]).toBe(options.type);
+            expect(attributes[SEMATTRS_DB_NAME]).toBe(options.database);
+            expect(attributes[SEMATTRS_DB_OPERATION]).toBe('SELECT');
+            expect(attributes[SEMATTRS_DB_STATEMENT]).toBe(query);
             await connection.close();
         });
     });

--- a/packages/instrumentation-typeorm/test/Connection.spec.ts
+++ b/packages/instrumentation-typeorm/test/Connection.spec.ts
@@ -1,7 +1,13 @@
 import 'mocha';
 import expect from 'expect';
 import { SpanStatusCode } from '@opentelemetry/api';
-import { SEMATTRS_DB_NAME, SEMATTRS_DB_OPERATION, SEMATTRS_DB_STATEMENT, SEMATTRS_DB_SYSTEM, SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+    SEMATTRS_DB_NAME,
+    SEMATTRS_DB_OPERATION,
+    SEMATTRS_DB_STATEMENT,
+    SEMATTRS_DB_SYSTEM,
+    SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import { TypeormInstrumentation } from '../src';
 import { getTestSpans, registerInstrumentationTesting } from '@opentelemetry/contrib-test-utils';
 

--- a/packages/instrumentation-typeorm/test/EntityManager.spec.ts
+++ b/packages/instrumentation-typeorm/test/EntityManager.spec.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import expect from 'expect';
 import { SpanStatusCode } from '@opentelemetry/api';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SemanticAttributes, SEMATTRS_DB_NAME, SEMATTRS_DB_OPERATION, SEMATTRS_DB_SQL_TABLE, SEMATTRS_DB_STATEMENT, SEMATTRS_DB_SYSTEM } from '@opentelemetry/semantic-conventions';
 import { TypeormInstrumentation } from '../src';
 import { getTestSpans } from '@opentelemetry/contrib-test-utils';
 
@@ -31,11 +31,11 @@ describe('EntityManager', () => {
             expect(typeOrmSpans.length).toBe(1);
             expect(typeOrmSpans[0].status.code).toBe(SpanStatusCode.UNSET);
             const attributes = typeOrmSpans[0].attributes;
-            expect(attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('user');
-            expect(attributes[SemanticAttributes.DB_SYSTEM]).toBe(options.type);
-            expect(attributes[SemanticAttributes.DB_NAME]).toBe(options.database);
-            expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('save');
-            expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe(JSON.stringify({ targetOrEntity: user }));
+            expect(attributes[SEMATTRS_DB_SQL_TABLE]).toBe('user');
+            expect(attributes[SEMATTRS_DB_SYSTEM]).toBe(options.type);
+            expect(attributes[SEMATTRS_DB_NAME]).toBe(options.database);
+            expect(attributes[SEMATTRS_DB_OPERATION]).toBe('save');
+            expect(attributes[SEMATTRS_DB_STATEMENT]).toBe(JSON.stringify({ targetOrEntity: user }));
             await connection.close();
         });
 
@@ -50,11 +50,11 @@ describe('EntityManager', () => {
             expect(typeOrmSpans.length).toBe(1);
             expect(typeOrmSpans[0].status.code).toBe(SpanStatusCode.UNSET);
             const attributes = typeOrmSpans[0].attributes;
-            expect(attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('user');
-            expect(attributes[SemanticAttributes.DB_SYSTEM]).toBe(options.type);
-            expect(attributes[SemanticAttributes.DB_NAME]).toBe(options.database);
-            expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('save');
-            expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe(JSON.stringify({ targetOrEntity: user }));
+            expect(attributes[SEMATTRS_DB_SQL_TABLE]).toBe('user');
+            expect(attributes[SEMATTRS_DB_SYSTEM]).toBe(options.type);
+            expect(attributes[SEMATTRS_DB_NAME]).toBe(options.database);
+            expect(attributes[SEMATTRS_DB_OPERATION]).toBe('save');
+            expect(attributes[SEMATTRS_DB_STATEMENT]).toBe(JSON.stringify({ targetOrEntity: user }));
             await connection.close();
         });
 
@@ -71,11 +71,11 @@ describe('EntityManager', () => {
             expect(typeOrmSpans.length).toBe(2);
             expect(typeOrmSpans[1].status.code).toBe(SpanStatusCode.UNSET);
             const attributes = typeOrmSpans[1].attributes;
-            expect(attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('user');
-            expect(attributes[SemanticAttributes.DB_SYSTEM]).toBe(options.type);
-            expect(attributes[SemanticAttributes.DB_NAME]).toBe(options.database);
-            expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('remove');
-            expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe(
+            expect(attributes[SEMATTRS_DB_SQL_TABLE]).toBe('user');
+            expect(attributes[SEMATTRS_DB_SYSTEM]).toBe(options.type);
+            expect(attributes[SEMATTRS_DB_NAME]).toBe(options.database);
+            expect(attributes[SEMATTRS_DB_OPERATION]).toBe('remove');
+            expect(attributes[SEMATTRS_DB_STATEMENT]).toBe(
                 JSON.stringify({ targetOrEntity: { id: 56, firstName: 'aspecto', lastName: 'io' } })
             );
             await connection.close();
@@ -94,11 +94,11 @@ describe('EntityManager', () => {
             expect(typeOrmSpans.length).toBe(2);
             expect(typeOrmSpans[1].status.code).toBe(SpanStatusCode.UNSET);
             const attributes = typeOrmSpans[1].attributes;
-            expect(attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('user');
-            expect(attributes[SemanticAttributes.DB_SYSTEM]).toBe(options.type);
-            expect(attributes[SemanticAttributes.DB_NAME]).toBe(options.database);
-            expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('update');
-            expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe(
+            expect(attributes[SEMATTRS_DB_SQL_TABLE]).toBe('user');
+            expect(attributes[SEMATTRS_DB_SYSTEM]).toBe(options.type);
+            expect(attributes[SEMATTRS_DB_NAME]).toBe(options.database);
+            expect(attributes[SEMATTRS_DB_OPERATION]).toBe('update');
+            expect(attributes[SEMATTRS_DB_STATEMENT]).toBe(
                 JSON.stringify({ target: 'User', criteria: 56, partialEntity })
             );
             await connection.close();
@@ -142,15 +142,15 @@ describe('EntityManager', () => {
             const sqlite1Span = spans[0];
             const sqlite2Span = spans[1];
 
-            expect(sqlite1Span.attributes[SemanticAttributes.DB_SYSTEM]).toBe(defaultOptions.type);
-            expect(sqlite1Span.attributes[SemanticAttributes.DB_NAME]).toBe(defaultOptions.database);
-            expect(sqlite1Span.attributes[SemanticAttributes.DB_OPERATION]).toBe('save');
-            expect(sqlite1Span.attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('user');
+            expect(sqlite1Span.attributes[SEMATTRS_DB_SYSTEM]).toBe(defaultOptions.type);
+            expect(sqlite1Span.attributes[SEMATTRS_DB_NAME]).toBe(defaultOptions.database);
+            expect(sqlite1Span.attributes[SEMATTRS_DB_OPERATION]).toBe('save');
+            expect(sqlite1Span.attributes[SEMATTRS_DB_SQL_TABLE]).toBe('user');
 
-            expect(sqlite2Span.attributes[SemanticAttributes.DB_SYSTEM]).toBe(options2.type);
-            expect(sqlite2Span.attributes[SemanticAttributes.DB_NAME]).toBe(options2.database);
-            expect(sqlite2Span.attributes[SemanticAttributes.DB_OPERATION]).toBe('remove');
-            expect(sqlite2Span.attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('user');
+            expect(sqlite2Span.attributes[SEMATTRS_DB_SYSTEM]).toBe(options2.type);
+            expect(sqlite2Span.attributes[SEMATTRS_DB_NAME]).toBe(options2.database);
+            expect(sqlite2Span.attributes[SEMATTRS_DB_OPERATION]).toBe('remove');
+            expect(sqlite2Span.attributes[SEMATTRS_DB_SQL_TABLE]).toBe('user');
             await sqlite1.close();
             await sqlite2.close();
         });

--- a/packages/instrumentation-typeorm/test/EntityManager.spec.ts
+++ b/packages/instrumentation-typeorm/test/EntityManager.spec.ts
@@ -1,7 +1,14 @@
 import 'mocha';
 import expect from 'expect';
 import { SpanStatusCode } from '@opentelemetry/api';
-import { SemanticAttributes, SEMATTRS_DB_NAME, SEMATTRS_DB_OPERATION, SEMATTRS_DB_SQL_TABLE, SEMATTRS_DB_STATEMENT, SEMATTRS_DB_SYSTEM } from '@opentelemetry/semantic-conventions';
+import {
+    SemanticAttributes,
+    SEMATTRS_DB_NAME,
+    SEMATTRS_DB_OPERATION,
+    SEMATTRS_DB_SQL_TABLE,
+    SEMATTRS_DB_STATEMENT,
+    SEMATTRS_DB_SYSTEM,
+} from '@opentelemetry/semantic-conventions';
 import { TypeormInstrumentation } from '../src';
 import { getTestSpans } from '@opentelemetry/contrib-test-utils';
 

--- a/packages/instrumentation-typeorm/test/QueryBuilder.spec.ts
+++ b/packages/instrumentation-typeorm/test/QueryBuilder.spec.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import expect from 'expect';
 import { SpanStatusCode } from '@opentelemetry/api';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_DB_NAME, SEMATTRS_DB_SQL_TABLE, SEMATTRS_DB_STATEMENT, SEMATTRS_DB_SYSTEM, SEMATTRS_DB_USER, SEMATTRS_NET_PEER_NAME, SEMATTRS_NET_PEER_PORT, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { TypeormInstrumentation } from '../src';
 import { getTestSpans, registerInstrumentationTesting } from '@opentelemetry/contrib-test-utils';
 const instrumentation = registerInstrumentationTesting(new TypeormInstrumentation());
@@ -27,13 +27,13 @@ describe('QueryBuilder', () => {
         expect(typeOrmSpans.length).toBe(1);
         expect(typeOrmSpans[0].status.code).toBe(SpanStatusCode.UNSET);
         const attributes = typeOrmSpans[0].attributes;
-        expect(attributes[SemanticAttributes.DB_SYSTEM]).toBe(connectionOptions.type);
-        expect(attributes[SemanticAttributes.DB_USER]).toBe(connectionOptions.username);
-        expect(attributes[SemanticAttributes.NET_PEER_NAME]).toBe(connectionOptions.host);
-        expect(attributes[SemanticAttributes.NET_PEER_PORT]).toBe(connectionOptions.port);
-        expect(attributes[SemanticAttributes.DB_NAME]).toBe(connectionOptions.database);
-        expect(attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('user');
-        expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe(
+        expect(attributes[SEMATTRS_DB_SYSTEM]).toBe(connectionOptions.type);
+        expect(attributes[SEMATTRS_DB_USER]).toBe(connectionOptions.username);
+        expect(attributes[SEMATTRS_NET_PEER_NAME]).toBe(connectionOptions.host);
+        expect(attributes[SEMATTRS_NET_PEER_PORT]).toBe(connectionOptions.port);
+        expect(attributes[SEMATTRS_DB_NAME]).toBe(connectionOptions.database);
+        expect(attributes[SEMATTRS_DB_SQL_TABLE]).toBe('user');
+        expect(attributes[SEMATTRS_DB_STATEMENT]).toBe(
             'SELECT "user"."id" AS "user_id", "user"."firstName" AS "user_firstName", "user"."lastName" AS "user_lastName" FROM "user" "user" WHERE "user"."id" = :userId'
         );
         await connection.close();

--- a/packages/instrumentation-typeorm/test/QueryBuilder.spec.ts
+++ b/packages/instrumentation-typeorm/test/QueryBuilder.spec.ts
@@ -1,7 +1,16 @@
 import 'mocha';
 import expect from 'expect';
 import { SpanStatusCode } from '@opentelemetry/api';
-import { SEMATTRS_DB_NAME, SEMATTRS_DB_SQL_TABLE, SEMATTRS_DB_STATEMENT, SEMATTRS_DB_SYSTEM, SEMATTRS_DB_USER, SEMATTRS_NET_PEER_NAME, SEMATTRS_NET_PEER_PORT, SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+    SEMATTRS_DB_NAME,
+    SEMATTRS_DB_SQL_TABLE,
+    SEMATTRS_DB_STATEMENT,
+    SEMATTRS_DB_SYSTEM,
+    SEMATTRS_DB_USER,
+    SEMATTRS_NET_PEER_NAME,
+    SEMATTRS_NET_PEER_PORT,
+    SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import { TypeormInstrumentation } from '../src';
 import { getTestSpans, registerInstrumentationTesting } from '@opentelemetry/contrib-test-utils';
 const instrumentation = registerInstrumentationTesting(new TypeormInstrumentation());

--- a/packages/instrumentation-typeorm/test/Repository.spec.ts
+++ b/packages/instrumentation-typeorm/test/Repository.spec.ts
@@ -6,7 +6,7 @@ import { getTestSpans, registerInstrumentationTesting } from '@opentelemetry/con
 const instrumentation = registerInstrumentationTesting(new TypeormInstrumentation());
 import { defaultOptions, User } from './utils';
 import * as typeorm from 'typeorm';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_DB_SQL_TABLE } from '@opentelemetry/semantic-conventions';
 
 describe('Repository', () => {
     beforeEach(() => {
@@ -28,7 +28,7 @@ describe('Repository', () => {
         expect(spans.length).toEqual(2);
         const span = spans[0];
         const attributes = span.attributes;
-        expect(attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('user');
+        expect(attributes[SEMATTRS_DB_SQL_TABLE]).toBe('user');
         await connection.close();
     });
 });

--- a/packages/instrumentation-typeorm/test/config.spec.ts
+++ b/packages/instrumentation-typeorm/test/config.spec.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import expect from 'expect';
 import { Span } from '@opentelemetry/sdk-trace-base';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_DB_NAME, SEMATTRS_DB_OPERATION, SEMATTRS_DB_SQL_TABLE, SEMATTRS_DB_STATEMENT, SEMATTRS_DB_SYSTEM, SEMATTRS_DB_USER, SEMATTRS_NET_PEER_NAME, SEMATTRS_NET_PEER_PORT, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { ExtendedDatabaseAttribute, TypeormInstrumentation, TypeormInstrumentationConfig } from '../src';
 import { getTestSpans, registerInstrumentationTesting } from '@opentelemetry/contrib-test-utils';
 
@@ -30,8 +30,8 @@ describe('TypeormInstrumentationConfig', () => {
         const attributes = typeOrmSpans[0].attributes;
 
         expect(attributes['test']).toBe(JSON.stringify(user));
-        expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('save');
-        expect(attributes[SemanticAttributes.DB_SYSTEM]).toBe(defaultOptions.type);
+        expect(attributes[SEMATTRS_DB_OPERATION]).toBe('save');
+        expect(attributes[SEMATTRS_DB_SYSTEM]).toBe(defaultOptions.type);
         await connection.close();
     });
 
@@ -50,7 +50,7 @@ describe('TypeormInstrumentationConfig', () => {
 
         expect(typeOrmSpans.length).toBe(1);
         const attributes = typeOrmSpans[0].attributes;
-        expect(attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('user');
+        expect(attributes[SEMATTRS_DB_SQL_TABLE]).toBe('user');
         expect(attributes['module.version']).toMatch(/\d{1,4}\.\d{1,4}\.\d{1,5}.*/);
         await connection.close();
     });
@@ -65,13 +65,13 @@ describe('TypeormInstrumentationConfig', () => {
 
         const findAndCountSpan = spans.find((s) => s.name.indexOf('findAndCount') !== -1);
         expect(findAndCountSpan).not.toBeUndefined();
-        expect(findAndCountSpan.attributes[SemanticAttributes.DB_OPERATION]).toBe('findAndCount');
-        expect(findAndCountSpan.attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('user');
+        expect(findAndCountSpan.attributes[SEMATTRS_DB_OPERATION]).toBe('findAndCount');
+        expect(findAndCountSpan.attributes[SEMATTRS_DB_SQL_TABLE]).toBe('user');
 
         const selectSpan = spans.find((s) => s.name.indexOf('select') !== -1);
         expect(selectSpan).not.toBeUndefined();
-        expect(selectSpan.attributes[SemanticAttributes.DB_OPERATION]).toBe('select');
-        expect(selectSpan.attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('user');
+        expect(selectSpan.attributes[SEMATTRS_DB_OPERATION]).toBe('select');
+        expect(selectSpan.attributes[SEMATTRS_DB_SQL_TABLE]).toBe('user');
         await connection.close();
     });
 
@@ -83,9 +83,9 @@ describe('TypeormInstrumentationConfig', () => {
         const spans = getTestSpans();
         expect(spans.length).toEqual(1);
         const attributes = spans[0].attributes;
-        expect(attributes[SemanticAttributes.DB_OPERATION]).toBe('findAndCount');
-        expect(attributes[SemanticAttributes.DB_SYSTEM]).toBe(defaultOptions.type);
-        expect(attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('user');
+        expect(attributes[SEMATTRS_DB_OPERATION]).toBe('findAndCount');
+        expect(attributes[SEMATTRS_DB_SYSTEM]).toBe(defaultOptions.type);
+        expect(attributes[SEMATTRS_DB_SQL_TABLE]).toBe('user');
         await connection.close();
     });
 
@@ -107,13 +107,13 @@ describe('TypeormInstrumentationConfig', () => {
         expect(typeOrmSpans.length).toBe(1);
         expect(typeOrmSpans[0].status.code).toBe(SpanStatusCode.UNSET);
         const attributes = typeOrmSpans[0].attributes;
-        expect(attributes[SemanticAttributes.DB_SYSTEM]).toBe(connectionOptions.type);
-        expect(attributes[SemanticAttributes.DB_USER]).toBe(connectionOptions.username);
-        expect(attributes[SemanticAttributes.NET_PEER_NAME]).toBe(connectionOptions.host);
-        expect(attributes[SemanticAttributes.NET_PEER_PORT]).toBe(connectionOptions.port);
-        expect(attributes[SemanticAttributes.DB_NAME]).toBe(connectionOptions.database);
-        expect(attributes[SemanticAttributes.DB_SQL_TABLE]).toBe('user');
-        expect(attributes[SemanticAttributes.DB_STATEMENT]).toBe(
+        expect(attributes[SEMATTRS_DB_SYSTEM]).toBe(connectionOptions.type);
+        expect(attributes[SEMATTRS_DB_USER]).toBe(connectionOptions.username);
+        expect(attributes[SEMATTRS_NET_PEER_NAME]).toBe(connectionOptions.host);
+        expect(attributes[SEMATTRS_NET_PEER_PORT]).toBe(connectionOptions.port);
+        expect(attributes[SEMATTRS_DB_NAME]).toBe(connectionOptions.database);
+        expect(attributes[SEMATTRS_DB_SQL_TABLE]).toBe('user');
+        expect(attributes[SEMATTRS_DB_STATEMENT]).toBe(
             'SELECT "user"."id" AS "user_id", "user"."firstName" AS "user_firstName", "user"."lastName" AS "user_lastName" FROM "user" "user" WHERE "user"."id" = :userId AND "user"."firstName" = :firstName AND "user"."lastName" = :lastName'
         );
         expect(attributes[ExtendedDatabaseAttribute.DB_STATEMENT_PARAMETERS]).toBe(

--- a/packages/instrumentation-typeorm/test/config.spec.ts
+++ b/packages/instrumentation-typeorm/test/config.spec.ts
@@ -1,7 +1,17 @@
 import 'mocha';
 import expect from 'expect';
 import { Span } from '@opentelemetry/sdk-trace-base';
-import { SEMATTRS_DB_NAME, SEMATTRS_DB_OPERATION, SEMATTRS_DB_SQL_TABLE, SEMATTRS_DB_STATEMENT, SEMATTRS_DB_SYSTEM, SEMATTRS_DB_USER, SEMATTRS_NET_PEER_NAME, SEMATTRS_NET_PEER_PORT, SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+    SEMATTRS_DB_NAME,
+    SEMATTRS_DB_OPERATION,
+    SEMATTRS_DB_SQL_TABLE,
+    SEMATTRS_DB_STATEMENT,
+    SEMATTRS_DB_SYSTEM,
+    SEMATTRS_DB_USER,
+    SEMATTRS_NET_PEER_NAME,
+    SEMATTRS_NET_PEER_PORT,
+    SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import { ExtendedDatabaseAttribute, TypeormInstrumentation, TypeormInstrumentationConfig } from '../src';
 import { getTestSpans, registerInstrumentationTesting } from '@opentelemetry/contrib-test-utils';
 

--- a/packages/propagation-utils/package.json
+++ b/packages/propagation-utils/package.json
@@ -36,7 +36,7 @@
     "devDependencies": {
         "@opentelemetry/api": "^1.8.0",
         "@types/node": "^14.14.8",
-        "typescript": "4.3.4"
+        "typescript": "5.4.5"
     },
     "peerDependencies": {
         "@opentelemetry/api": "^1.8.0"

--- a/packages/propagation-utils/package.json
+++ b/packages/propagation-utils/package.json
@@ -34,11 +34,11 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.6.0",
+        "@opentelemetry/api": "^1.8.0",
         "@types/node": "^14.14.8",
         "typescript": "4.3.4"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.6.0"
+        "@opentelemetry/api": "^1.8.0"
     }
 }

--- a/packages/span-transformations/package.json
+++ b/packages/span-transformations/package.json
@@ -24,8 +24,8 @@
         "test": "mocha"
     },
     "dependencies": {
-        "@opentelemetry/api": "^1.6.0",
-        "@opentelemetry/core": "^1.17.1",
+        "@opentelemetry/api": "^1.8.0",
+        "@opentelemetry/core": "^1.24.1",
         "@opentelemetry/sdk-trace-base": "^1.17.1"
     },
     "devDependencies": {

--- a/packages/span-transformations/package.json
+++ b/packages/span-transformations/package.json
@@ -33,7 +33,7 @@
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
         "ts-node": "^9.1.1",
-        "typescript": "4.3.4"
+        "typescript": "5.4.5"
     },
     "mocha": {
         "extension": [

--- a/packages/span-transformations/package.json
+++ b/packages/span-transformations/package.json
@@ -32,7 +32,7 @@
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
-        "ts-node": "^9.1.1",
+        "ts-node": "^10.9.2",
         "typescript": "5.4.5"
     },
     "mocha": {

--- a/propagators/propagator-selective/package.json
+++ b/propagators/propagator-selective/package.json
@@ -36,7 +36,7 @@
         "expect": "^26.6.2",
         "mocha": "^8.4.0",
         "sinon": "^12.0.1",
-        "ts-node": "^9.1.1",
+        "ts-node": "^10.9.2",
         "typescript": "5.4.5"
     },
     "mocha": {

--- a/propagators/propagator-selective/package.json
+++ b/propagators/propagator-selective/package.json
@@ -46,7 +46,7 @@
         "spec": "test/**/*.spec.ts",
         "require": [
             "ts-node/register",
-            "opentelemetry-instrumentation-mocha"
+            "aspecto-opentelemetry-instrumentation-mocha"
         ]
     }
 }

--- a/propagators/propagator-selective/package.json
+++ b/propagators/propagator-selective/package.json
@@ -28,10 +28,10 @@
         "url": "https://github.com/aspecto-io/opentelemetry-ext-js/issues"
     },
     "peerDependencies": {
-        "@opentelemetry/api": "^1.6.0"
+        "@opentelemetry/api": "^1.8.0"
     },
     "devDependencies": {
-        "@opentelemetry/api": "^1.6.0",
+        "@opentelemetry/api": "^1.8.0",
         "@types/mocha": "^8.2.2",
         "expect": "^26.6.2",
         "mocha": "^8.4.0",

--- a/propagators/propagator-selective/package.json
+++ b/propagators/propagator-selective/package.json
@@ -37,7 +37,7 @@
         "mocha": "^8.4.0",
         "sinon": "^12.0.1",
         "ts-node": "^9.1.1",
-        "typescript": "4.3.4"
+        "typescript": "5.4.5"
     },
     "mocha": {
         "extension": [

--- a/propagators/propagator-selective/src/SelectivePropagator.ts
+++ b/propagators/propagator-selective/src/SelectivePropagator.ts
@@ -2,7 +2,10 @@ import { Context, TextMapGetter, TextMapPropagator, TextMapSetter } from '@opent
 import { SelectivePropagatorConfig } from './types';
 
 export class SelectivePropagator implements TextMapPropagator {
-    constructor(private propagator: TextMapPropagator, private config: SelectivePropagatorConfig = {}) {}
+    constructor(
+        private propagator: TextMapPropagator,
+        private config: SelectivePropagatorConfig = {}
+    ) {}
 
     inject(context: Context, carrier: any, setter: TextMapSetter<any>): void {
         if (!this.config.injectEnabled) return;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,6 +13,7 @@
         "types": ["node"],
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
-        "noImplicitOverride": true
+        "noImplicitOverride": true,
+        "skipLibCheck": true
     }
 }


### PR DESCRIPTION
This pull request contains a number of updates across the codebase, primarily focused on upgrading dependencies and adjusting code to align with these updates. The changes span across multiple files, including GitHub workflow files, package.json files in various directories, and several TypeScript files. 

The key changes can be grouped into three main categories:

**1. Updates to GitHub workflow files:**
- `.github/workflows/daily-test.yml` and `.github/workflows/test.yml`: The Neo4j image version was updated from 4.2.3 to 4.4.34, and the `NEO4J_AUTH` environment variable was changed from `neo4j/test` to `neo4j/your_password`. Additionally, the Node.js version used was updated from 14 to 18. [[1]](diffhunk://#diff-26da02d6bd1ffe3540c8ebf08a9acd9ef7efbc1f6b1006e26d78df8e90bdd8b7L27-R32) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L26-R31) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L42-R45)

**2. Updates to package.json files:**
- Multiple `package.json` files in various directories (`detectors/node/resource-detector-deployment`, `detectors/node/resource-detector-git`, `detectors/node/resource-detector-service`, `detectors/resource-detector-sync-api`, `packages/instrumentation-elasticsearch`, `packages/instrumentation-express`): These files saw updates to their dependencies, with versions of `@opentelemetry/api`, `@opentelemetry/resources`, `@opentelemetry/semantic-conventions`, `ts-node`, and `typescript` being updated. The `opentelemetry-instrumentation-mocha` dependency was replaced with `aspecto-opentelemetry-instrumentation-mocha`. [[1]](diffhunk://#diff-1ac6dbfc2fb1680764b985c25f920c64fe33d94624fa65e3d4cffb3120fe3dfaL36-R50) [[2]](diffhunk://#diff-c160e1cd1d11d5dda5983d99a0fc09074154b61c47165910363512e6aaf1feb5L37-R54) [[3]](diffhunk://#diff-131362020f49cc22eff10891d391e9f20d84562cccc9b4b1d579b358987ed59eL36-R51) [[4]](diffhunk://#diff-c793df4b242a1e60bf5a9c7daf9eeb50fdfa04bd065ca19c77eb1ee76c881379L33-R41) [[5]](diffhunk://#diff-803fd9d86a20faa8fc96d5c01a12a66aedc63a52e0b11f46f0de1ff2c4d67c17L45-R66) [[6]](diffhunk://#diff-3323e3510f58e7c8d1ad6c2c3de2cf9753bb3382053964213b007a04bf28b5bcL35-R59)
- `lerna.json` and `package.json` at the root level: The `useWorkspaces` property was removed from `lerna.json`, and the `postinstall` script and the version of `prettier` were updated in `package.json`. [[1]](diffhunk://#diff-2d72bdead8afa0798d18995311992d684348a694c2d5e214e8e4d2b6153e4821L4-R4) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L11-R21)

**3. Updates to TypeScript files:**
- `packages/instrumentation-elasticsearch/src/elasticsearch.ts` and `packages/instrumentation-elasticsearch/src/utils.ts`: These files saw changes to the import statements for `SemanticAttributes` from `@opentelemetry/semantic-conventions`, replacing them with specific semantic attributes. There were also several changes in the `ElasticsearchInstrumentation` class and the `startSpan` and `getNetAttributes` functions to use the new semantic attributes. [[1]](diffhunk://#diff-782a93844c8bf94dd1c9061593b7e36aae002312d0865e82c4ef9208cb54da4eL13-R13) [[2]](diffhunk://#diff-782a93844c8bf94dd1c9061593b7e36aae002312d0865e82c4ef9208cb54da4eL24-R24) [[3]](diffhunk://#diff-782a93844c8bf94dd1c9061593b7e36aae002312d0865e82c4ef9208cb54da4eL39-R50) [[4]](diffhunk://#diff-782a93844c8bf94dd1c9061593b7e36aae002312d0865e82c4ef9208cb54da4eL123-R129) [[5]](diffhunk://#diff-bb4198a6ab66b57872723cc321aa69a67cd4ee2926d03be09907fbf515450612L4-R9) [[6]](diffhunk://#diff-bb4198a6ab66b57872723cc321aa69a67cd4ee2926d03be09907fbf515450612L30-R35) [[7]](diffhunk://#diff-bb4198a6ab66b57872723cc321aa69a67cd4ee2926d03be09907fbf515450612L63-R70)
- [`packages/instrumentation-elasticsearch/test/utils.spec.ts`](diffhunk://#diff-b2dcdae9c075abfb014963f3679fad7d8cf21fb08d156445d4161022b84e0845L6-R11): The import statement for `SemanticAttributes` was updated, and the test cases were adjusted to use the new semantic attributes. [[1]](diffhunk://#diff-b2dcdae9c075abfb014963f3679fad7d8cf21fb08d156445d4161022b84e0845L6-R11) [[2]](diffhunk://#diff-b2dcdae9c075abfb014963f3679fad7d8cf21fb08d156445d4161022b84e0845L95-R108) [[3]](diffhunk://#diff-b2dcdae9c075abfb014963f3679fad7d8cf21fb08d156445d4161022b84e0845L193-R198)