### PR TITLE
chore: update node versions

### DIFF
--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x, 20.x]
 
     services:
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 18
           registry-url: https://registry.npmjs.org/
 
       - name: Install Packages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 18
           registry-url: https://registry.npmjs.org/
 
       - name: Configure CI Git User


### PR DESCRIPTION
This pull request includes updates to the Node.js versions used in GitHub Actions workflows. The changes are made in `.github/workflows/daily-test.yml`, `.github/workflows/prerelease.yml`, and `.github/workflows/publish.yml`. The Node.js versions are updated to newer versions to ensure the workflows are running on the latest and supported versions of Node.js.

Here are the key changes:

Node.js version updates in GitHub Actions workflows:

* [`.github/workflows/daily-test.yml`](diffhunk://#diff-26da02d6bd1ffe3540c8ebf08a9acd9ef7efbc1f6b1006e26d78df8e90bdd8b7L17-R17): The Node.js versions used in the test matrix have been updated from `[10.x, 12.x, 14.x, 16.x]` to `[14.x, 16.x, 18.x, 20.x]`.
* [`.github/workflows/prerelease.yml`](diffhunk://#diff-884bb2e52646d4b226c75e5dd7c196f9d654accb529fef4b6eeb401daa83144eL16-R16): The Node.js version used in the setup step has been updated from `14` to `18`.
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L27-R27): The Node.js version used in the setup step has been updated from `14` to `18`.